### PR TITLE
Cross links to BMS Rev 12 PR

### DIFF
--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -4496,8 +4496,8 @@ chip</description>
 <rectangle x1="-0.2286" y1="-0.381" x2="0.2286" y2="0.381" layer="21"/>
 <smd name="1" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
 <smd name="2" x="0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<text x="-0.8636" y="0.6096" size="0.4064" layer="25" font="vector">&gt;NAME</text>
-<text x="-0.8636" y="-1.016" size="0.4064" layer="27" font="vector">&gt;VALUE</text>
+<text x="-0.889" y="0.762" size="0.4064" layer="25" font="vector">&gt;NAME</text>
+<text x="-1.016" y="-1.143" size="0.4064" layer="27" font="vector">&gt;VALUE</text>
 </package>
 <package name="0805">
 <smd name="1" x="-1.025" y="0" dx="1.4" dy="1.5" layer="1"/>
@@ -6439,6 +6439,73 @@ Source: http://www.alphapotentiometers.net/html/16mm_pot_2.html</description>
 <text x="22.86" y="1.27" size="1.778" layer="25" ratio="10" rot="R90">&gt;NAME</text>
 <text x="-0.635" y="1.27" size="1.778" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 </package>
+<package name="TEENSY_3.5_EXT">
+<pad name="AGND" x="16.51" y="57.15" drill="0.8" shape="long"/>
+<pad name="D13" x="16.51" y="26.67" drill="0.8" shape="long"/>
+<pad name="A0" x="16.51" y="29.21" drill="0.8" shape="long"/>
+<pad name="A1" x="16.51" y="31.75" drill="0.8" shape="long"/>
+<pad name="A2" x="16.51" y="34.29" drill="0.8" shape="long"/>
+<pad name="A3" x="16.51" y="36.83" drill="0.8" shape="long"/>
+<pad name="A4" x="16.51" y="39.37" drill="0.8" shape="long"/>
+<pad name="A5" x="16.51" y="41.91" drill="0.8" shape="long"/>
+<pad name="A6" x="16.51" y="44.45" drill="0.8" shape="long"/>
+<pad name="A7" x="16.51" y="46.99" drill="0.8" shape="long"/>
+<pad name="A8" x="16.51" y="49.53" drill="0.8" shape="long"/>
+<pad name="D12" x="1.27" y="26.67" drill="0.8" shape="long"/>
+<pad name="D11" x="1.27" y="29.21" drill="0.8" shape="long"/>
+<pad name="D5" x="1.27" y="44.45" drill="0.8" shape="long"/>
+<pad name="D4(CANRX)" x="1.27" y="46.99" drill="0.8" shape="long"/>
+<pad name="D3(CANTX)" x="1.27" y="49.53" drill="0.8" shape="long"/>
+<pad name="D2" x="1.27" y="52.07" drill="0.8" shape="long"/>
+<pad name="GND" x="1.27" y="59.69" drill="0.8" shape="long"/>
+<pad name="VIN" x="16.51" y="59.69" drill="0.8" shape="long"/>
+<pad name="3.3V" x="16.51" y="54.61" drill="0.8" shape="long"/>
+<pad name="A9" x="16.51" y="52.07" drill="0.8" shape="long"/>
+<pad name="D0(RX1)" x="1.27" y="57.15" drill="0.8" shape="long" rot="R180"/>
+<pad name="D1(TX1)" x="1.27" y="54.61" drill="0.8" shape="long" rot="R180"/>
+<pad name="D10(TX2)" x="1.27" y="31.75" drill="0.8" shape="long"/>
+<pad name="D6" x="1.27" y="41.91" drill="0.8" shape="long" rot="R180"/>
+<pad name="D7(RX3)" x="1.27" y="39.37" drill="0.8" shape="long" rot="R180"/>
+<pad name="D8(TX3)" x="1.27" y="36.83" drill="0.8" shape="long" rot="R180"/>
+<pad name="D9(RX2)" x="1.27" y="34.29" drill="0.8" shape="long" rot="R180"/>
+<wire x1="17.78" y1="60.96" x2="17.78" y2="0" width="0.127" layer="21"/>
+<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="61.722" x2="12.7" y2="61.722" width="0.127" layer="21"/>
+<wire x1="12.7" y1="61.722" x2="12.7" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="60.96" x2="5.08" y2="61.722" width="0.127" layer="21"/>
+<wire x1="0" y1="60.96" x2="5.08" y2="60.96" width="0.127" layer="21"/>
+<wire x1="12.7" y1="60.96" x2="17.78" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="60.96" x2="5.08" y2="55.88" width="0.127" layer="21"/>
+<wire x1="5.08" y1="55.88" x2="12.7" y2="55.88" width="0.127" layer="21"/>
+<wire x1="12.7" y1="55.88" x2="12.7" y2="60.96" width="0.127" layer="21"/>
+<pad name="3.3V_1" x="1.27" y="24.13" drill="0.8" shape="long"/>
+<pad name="D24" x="1.27" y="21.59" drill="0.8" shape="long"/>
+<pad name="D25" x="1.27" y="19.05" drill="0.8" shape="long"/>
+<pad name="D26" x="1.27" y="16.51" drill="0.8" shape="long"/>
+<pad name="D27" x="1.27" y="13.97" drill="0.8" shape="long"/>
+<pad name="D28" x="1.27" y="11.43" drill="0.8" shape="long"/>
+<pad name="D29" x="1.27" y="8.89" drill="0.8" shape="long"/>
+<pad name="D30" x="1.27" y="6.35" drill="0.8" shape="long"/>
+<pad name="A12" x="1.27" y="3.81" drill="0.8" shape="long"/>
+<pad name="A13" x="1.27" y="1.27" drill="0.8" shape="long"/>
+<pad name="GND_1" x="16.51" y="24.13" drill="0.8" shape="long"/>
+<pad name="A22" x="16.51" y="21.59" drill="0.8" shape="long"/>
+<pad name="A21" x="16.51" y="19.05" drill="0.8" shape="long"/>
+<pad name="A20" x="16.51" y="16.51" drill="0.8" shape="long"/>
+<pad name="A19" x="16.51" y="13.97" drill="0.8" shape="long"/>
+<pad name="A18" x="16.51" y="11.43" drill="0.8" shape="long"/>
+<pad name="A17" x="16.51" y="8.89" drill="0.8" shape="long"/>
+<pad name="A16" x="16.51" y="6.35" drill="0.8" shape="long"/>
+<pad name="A15" x="16.51" y="3.81" drill="0.8" shape="long"/>
+<pad name="A14" x="16.51" y="1.27" drill="0.8" shape="long"/>
+<pad name="VBAT" x="3.81" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<pad name="3.3V_2" x="6.35" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<pad name="GND_2" x="8.89" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<pad name="PROG" x="11.43" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<pad name="RST" x="13.97" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<text x="8.89" y="58.7375" size="2.54" layer="21" align="center">3.5</text>
+</package>
 <package name="CR-2450/G1AN">
 <circle x="0" y="0" radius="12.446" width="0.254" layer="21"/>
 <pad name="-" x="0" y="-5.08" drill="0.8" shape="long" rot="R90"/>
@@ -6608,10 +6675,6 @@ Source: transistor-fet.lbr</description>
 <pad name="1" x="-2.54" y="0" drill="1" shape="square"/>
 <pad name="2" x="0" y="0" drill="1"/>
 <pad name="3" x="2.54" y="0" drill="1"/>
-</package>
-<package name="KEYSTONE5222">
-<smd name="P$1" x="0" y="0" dx="12.805" dy="14.71" layer="1"/>
-<text x="0" y="-6.604" size="0.508" layer="25" align="top-center">&gt;NAME</text>
 </package>
 <package name="0S102011MS2QS1">
 <pad name="P$2" x="0" y="0" drill="0.8" shape="long" rot="R90"/>
@@ -7628,6 +7691,53 @@ MX150L™ Vertical PCB Header</description>
 <wire x1="0" y1="0" x2="0.6" y2="0.6" width="0.254" layer="21" curve="-90"/>
 <wire x1="0.6" y1="0.6" x2="1.2" y2="0" width="0.254" layer="21" curve="-90"/>
 </package>
+<package name="TEENSY_LC">
+<pad name="AGND" x="16.51" y="31.75" drill="0.8" shape="long"/>
+<pad name="D13" x="16.51" y="1.27" drill="0.8" shape="long"/>
+<pad name="A0" x="16.51" y="3.81" drill="0.8" shape="long"/>
+<pad name="A1" x="16.51" y="6.35" drill="0.8" shape="long"/>
+<pad name="A2" x="16.51" y="8.89" drill="0.8" shape="long"/>
+<pad name="A3" x="16.51" y="11.43" drill="0.8" shape="long"/>
+<pad name="A4" x="16.51" y="13.97" drill="0.8" shape="long"/>
+<pad name="A5" x="16.51" y="16.51" drill="0.8" shape="long"/>
+<pad name="A6" x="16.51" y="19.05" drill="0.8" shape="long"/>
+<pad name="A7" x="16.51" y="21.59" drill="0.8" shape="long"/>
+<pad name="A8" x="16.51" y="24.13" drill="0.8" shape="long"/>
+<pad name="D12" x="1.27" y="1.27" drill="0.8" shape="long"/>
+<pad name="D11" x="1.27" y="3.81" drill="0.8" shape="long"/>
+<pad name="D5(TX1)" x="1.27" y="19.05" drill="0.8" shape="long"/>
+<pad name="D4(TX1)" x="1.27" y="21.59" drill="0.8" shape="long"/>
+<pad name="D3(RX1)" x="1.27" y="24.13" drill="0.8" shape="long"/>
+<pad name="D2" x="1.27" y="26.67" drill="0.8" shape="long"/>
+<pad name="GND" x="1.27" y="34.29" drill="0.8" shape="long"/>
+<pad name="VIN" x="16.51" y="34.29" drill="0.8" shape="long"/>
+<pad name="3.3V" x="16.51" y="29.21" drill="0.8" shape="long"/>
+<pad name="A9" x="16.51" y="26.67" drill="0.8" shape="long"/>
+<pad name="D0(RX1)" x="1.27" y="31.75" drill="0.8" shape="long" rot="R180"/>
+<pad name="D1(TX1)" x="1.27" y="29.21" drill="0.8" shape="long" rot="R180"/>
+<pad name="D10(TX2)" x="1.27" y="6.35" drill="0.8" shape="long"/>
+<pad name="D6(RX3)" x="1.27" y="16.51" drill="0.8" shape="long" rot="R180"/>
+<pad name="D7(RX3)" x="1.27" y="13.97" drill="0.8" shape="long" rot="R180"/>
+<pad name="D8(TX3)" x="1.27" y="11.43" drill="0.8" shape="long" rot="R180"/>
+<pad name="D9(RX2)" x="1.27" y="8.89" drill="0.8" shape="long" rot="R180"/>
+<wire x1="17.78" y1="35.56" x2="17.78" y2="0" width="0.127" layer="21"/>
+<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="36.322" x2="12.7" y2="36.322" width="0.127" layer="21"/>
+<wire x1="12.7" y1="36.322" x2="12.7" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="35.56" x2="5.08" y2="36.322" width="0.127" layer="21"/>
+<wire x1="0" y1="35.56" x2="5.08" y2="35.56" width="0.127" layer="21"/>
+<wire x1="12.7" y1="35.56" x2="17.78" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="35.56" x2="5.08" y2="30.48" width="0.127" layer="21"/>
+<wire x1="5.08" y1="30.48" x2="12.7" y2="30.48" width="0.127" layer="21"/>
+<wire x1="12.7" y1="30.48" x2="12.7" y2="35.56" width="0.127" layer="21"/>
+<pad name="17VIN" x="3.81" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<pad name="3.3V2" x="6.35" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<pad name="GND2" x="8.89" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<pad name="PGRM" x="11.43" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<pad name="A12" x="13.97" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<text x="9.2075" y="33.3375" size="2.54" layer="21" align="center">LC</text>
+</package>
 <package name="LED_RGB_5MM">
 <circle x="0" y="0" radius="2.9464" width="0.127" layer="21"/>
 <pad name="P$3" x="0.635" y="0" drill="0.889" diameter="1.016" shape="long" rot="R90"/>
@@ -7843,14 +7953,6 @@ MX150L™ Vertical PCB Header</description>
 <text x="0.69" y="0.83" size="0.8128" layer="25">&gt;NAME</text>
 <text x="0.24" y="-10.56" size="0.8128" layer="25">&gt;VALUE</text>
 </package>
-<package name="5X20MM_FUSE">
-<smd name="P$1" x="-7.5" y="0" dx="5" dy="5.5" layer="1" rot="R90"/>
-<smd name="P$2" x="7.5" y="0" dx="5" dy="5.5" layer="1" rot="R90"/>
-<wire x1="-10" y1="2.6" x2="10" y2="2.6" width="0.127" layer="21"/>
-<wire x1="10" y1="2.6" x2="10" y2="-2.6" width="0.127" layer="21"/>
-<wire x1="10" y1="-2.6" x2="-10" y2="-2.6" width="0.127" layer="21"/>
-<wire x1="-10" y1="-2.6" x2="-10" y2="2.6" width="0.127" layer="21"/>
-</package>
 <package name="SM51589PEL">
 <smd name="1" x="0" y="0" dx="1.905" dy="0.635" layer="1" rot="R90"/>
 <smd name="2" x="1.27" y="0" dx="1.905" dy="0.635" layer="1" rot="R90"/>
@@ -7972,15 +8074,6 @@ MX150L™ Vertical PCB Header</description>
 <wire x1="7.6" y1="-0.2" x2="7.6" y2="-4.8" width="0.127" layer="21"/>
 <wire x1="7.6" y1="-4.8" x2="0.2" y2="-4.8" width="0.127" layer="21"/>
 <wire x1="0.2" y1="-4.8" x2="0.2" y2="-0.2" width="0.127" layer="21"/>
-</package>
-<package name="PWR163">
-<smd name="PAD" x="0" y="0" dx="7.874" dy="8.509" layer="1"/>
-<smd name="1" x="-2.54" y="-7.9375" dx="3.81" dy="1.651" layer="1" rot="R90"/>
-<smd name="2" x="2.54" y="-7.9375" dx="3.81" dy="1.651" layer="1" rot="R90"/>
-<wire x1="-4.064" y1="3.6195" x2="4.064" y2="3.6195" width="0.127" layer="21"/>
-<wire x1="4.064" y1="3.6195" x2="4.064" y2="-3.6195" width="0.127" layer="21"/>
-<wire x1="4.064" y1="-3.6195" x2="-4.064" y2="-3.6195" width="0.127" layer="21"/>
-<wire x1="-4.064" y1="-3.6195" x2="-4.064" y2="3.6195" width="0.127" layer="21"/>
 </package>
 <package name="SS-14D0839-VG5PA">
 <pad name="1" x="-4.57" y="-0.35" drill="0.85" shape="square"/>
@@ -8879,7 +8972,7 @@ Source: transistor-fet.lbr</description>
 <rectangle x1="3.7084" y1="2.159" x2="4.5212" y2="6.858" layer="49"/>
 <rectangle x1="5.08" y1="-0.381" x2="5.8928" y2="6.858" layer="49"/>
 </package>
-<package name="TEENSY_3.2_EXT_12ANALOG">
+<package name="TEENSY_3.2_12ANALOG">
 <pad name="AGND" x="16.51" y="31.75" drill="0.8" shape="long"/>
 <pad name="D13" x="16.51" y="1.27" drill="0.8" shape="long"/>
 <pad name="A0" x="16.51" y="3.81" drill="0.8" shape="long"/>
@@ -9852,442 +9945,6 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <pad name="C2" x="25.25" y="11.45" drill="0.85" diameter="1.9" shape="square"/>
 <pad name="C1" x="4.95" y="11.45" drill="0.85" diameter="1.9" shape="square"/>
 </package>
-<package name="TEENSY_4.0_EXT">
-<pad name="GND3" x="16.51" y="31.75" drill="0.8" shape="long"/>
-<pad name="D13" x="16.51" y="1.27" drill="0.8" shape="long"/>
-<pad name="(TX3)A0" x="16.51" y="3.81" drill="0.8" shape="long"/>
-<pad name="(RX3)A1" x="16.51" y="6.35" drill="0.8" shape="long"/>
-<pad name="A2" x="16.51" y="8.89" drill="0.8" shape="long"/>
-<pad name="A3" x="16.51" y="11.43" drill="0.8" shape="long"/>
-<pad name="A4" x="16.51" y="13.97" drill="0.8" shape="long"/>
-<pad name="A5" x="16.51" y="16.51" drill="0.8" shape="long"/>
-<pad name="A6" x="16.51" y="19.05" drill="0.8" shape="long"/>
-<pad name="A7" x="16.51" y="21.59" drill="0.8" shape="long"/>
-<pad name="(CANTX)A8" x="16.51" y="24.13" drill="0.8" shape="long"/>
-<pad name="D12" x="1.27" y="1.27" drill="0.8" shape="long"/>
-<pad name="D11" x="1.27" y="3.81" drill="0.8" shape="long"/>
-<pad name="D5" x="1.27" y="19.05" drill="0.8" shape="long"/>
-<pad name="D4" x="1.27" y="21.59" drill="0.8" shape="long"/>
-<pad name="D3" x="1.27" y="24.13" drill="0.8" shape="long"/>
-<pad name="D2" x="1.27" y="26.67" drill="0.8" shape="long"/>
-<pad name="GND" x="1.27" y="34.29" drill="0.8" shape="long"/>
-<pad name="VIN" x="16.51" y="34.29" drill="0.8" shape="long"/>
-<pad name="3.3V2" x="16.51" y="29.21" drill="0.8" shape="long"/>
-<pad name="(CANRX)A9" x="16.51" y="26.67" drill="0.8" shape="long"/>
-<pad name="D0(RX1)" x="1.27" y="31.75" drill="0.8" shape="long" rot="R180"/>
-<pad name="D1(TX1)" x="1.27" y="29.21" drill="0.8" shape="long" rot="R180"/>
-<pad name="D10" x="1.27" y="6.35" drill="0.8" shape="long"/>
-<pad name="D6" x="1.27" y="16.51" drill="0.8" shape="long" rot="R180"/>
-<pad name="D7(RX2)" x="1.27" y="13.97" drill="0.8" shape="long" rot="R180"/>
-<pad name="D8(TX2)" x="1.27" y="11.43" drill="0.8" shape="long" rot="R180"/>
-<pad name="D9" x="1.27" y="8.89" drill="0.8" shape="long" rot="R180"/>
-<wire x1="17.78" y1="35.56" x2="17.78" y2="0" width="0.127" layer="21"/>
-<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
-<wire x1="0" y1="0" x2="0" y2="35.56" width="0.127" layer="21"/>
-<wire x1="5.08" y1="36.322" x2="12.7" y2="36.322" width="0.127" layer="21"/>
-<wire x1="12.7" y1="36.322" x2="12.7" y2="35.56" width="0.127" layer="21"/>
-<wire x1="5.08" y1="35.56" x2="5.08" y2="36.322" width="0.127" layer="21"/>
-<wire x1="0" y1="35.56" x2="5.08" y2="35.56" width="0.127" layer="21"/>
-<wire x1="12.7" y1="35.56" x2="17.78" y2="35.56" width="0.127" layer="21"/>
-<wire x1="5.08" y1="35.56" x2="5.08" y2="30.48" width="0.127" layer="21"/>
-<wire x1="5.08" y1="30.48" x2="12.7" y2="30.48" width="0.127" layer="21"/>
-<wire x1="12.7" y1="30.48" x2="12.7" y2="35.56" width="0.127" layer="21"/>
-<pad name="VBAT" x="3.81" y="1.27" drill="0.8" shape="long" rot="R90"/>
-<pad name="3.3V" x="6.35" y="1.27" drill="0.8" shape="long" rot="R90"/>
-<pad name="GND2" x="8.89" y="1.27" drill="0.8" shape="long" rot="R90"/>
-<pad name="PGRM" x="11.43" y="1.27" drill="0.8" shape="long" rot="R90"/>
-<pad name="ON/OFF" x="13.97" y="1.27" drill="0.8" shape="long" rot="R90"/>
-<text x="8.89" y="33.3375" size="2.54" layer="21" align="center">4.0</text>
-</package>
-<package name="TEENSY_4.0_SIMPLE">
-<pad name="GND2" x="16.51" y="31.75" drill="0.8" shape="long"/>
-<pad name="D13" x="16.51" y="1.27" drill="0.8" shape="long"/>
-<pad name="(TX3)A0" x="16.51" y="3.81" drill="0.8" shape="long"/>
-<pad name="(RX3)A1" x="16.51" y="6.35" drill="0.8" shape="long"/>
-<pad name="A2" x="16.51" y="8.89" drill="0.8" shape="long"/>
-<pad name="A3" x="16.51" y="11.43" drill="0.8" shape="long"/>
-<pad name="A4" x="16.51" y="13.97" drill="0.8" shape="long"/>
-<pad name="A5" x="16.51" y="16.51" drill="0.8" shape="long"/>
-<pad name="A6" x="16.51" y="19.05" drill="0.8" shape="long"/>
-<pad name="(CANTX)A7" x="16.51" y="21.59" drill="0.8" shape="long"/>
-<pad name="(CANRX)A8" x="16.51" y="24.13" drill="0.8" shape="long"/>
-<pad name="D12" x="1.27" y="1.27" drill="0.8" shape="long"/>
-<pad name="D11" x="1.27" y="3.81" drill="0.8" shape="long"/>
-<pad name="D5" x="1.27" y="19.05" drill="0.8" shape="long"/>
-<pad name="D4" x="1.27" y="21.59" drill="0.8" shape="long"/>
-<pad name="D3" x="1.27" y="24.13" drill="0.8" shape="long"/>
-<pad name="D2" x="1.27" y="26.67" drill="0.8" shape="long"/>
-<pad name="GND" x="1.27" y="34.29" drill="0.8" shape="long"/>
-<pad name="VIN" x="16.51" y="34.29" drill="0.8" shape="long"/>
-<pad name="3.3V" x="16.51" y="29.21" drill="0.8" shape="long"/>
-<pad name="A9" x="16.51" y="26.67" drill="0.8" shape="long"/>
-<pad name="D0(RX1)" x="1.27" y="31.75" drill="0.8" shape="long" rot="R180"/>
-<pad name="D1(TX1)" x="1.27" y="29.21" drill="0.8" shape="long" rot="R180"/>
-<pad name="D10" x="1.27" y="6.35" drill="0.8" shape="long"/>
-<pad name="D6" x="1.27" y="16.51" drill="0.8" shape="long" rot="R180"/>
-<pad name="D7(RX2)" x="1.27" y="13.97" drill="0.8" shape="long" rot="R180"/>
-<pad name="D8(TX2)" x="1.27" y="11.43" drill="0.8" shape="long" rot="R180"/>
-<pad name="D9" x="1.27" y="8.89" drill="0.8" shape="long" rot="R180"/>
-<wire x1="17.78" y1="35.56" x2="17.78" y2="0" width="0.127" layer="21"/>
-<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
-<wire x1="0" y1="0" x2="0" y2="35.56" width="0.127" layer="21"/>
-<wire x1="5.08" y1="36.322" x2="12.7" y2="36.322" width="0.127" layer="21"/>
-<wire x1="12.7" y1="36.322" x2="12.7" y2="35.56" width="0.127" layer="21"/>
-<wire x1="5.08" y1="35.56" x2="5.08" y2="36.322" width="0.127" layer="21"/>
-<wire x1="0" y1="35.56" x2="5.08" y2="35.56" width="0.127" layer="21"/>
-<wire x1="12.7" y1="35.56" x2="17.78" y2="35.56" width="0.127" layer="21"/>
-<wire x1="5.08" y1="35.56" x2="5.08" y2="30.48" width="0.127" layer="21"/>
-<wire x1="5.08" y1="30.48" x2="12.7" y2="30.48" width="0.127" layer="21"/>
-<wire x1="12.7" y1="30.48" x2="12.7" y2="35.56" width="0.127" layer="21"/>
-<text x="8.89" y="33.3375" size="2.54" layer="21" align="center">4.0</text>
-</package>
-<package name="TEENSY_3.6_EXT_RTC">
-<pad name="AGND" x="16.51" y="57.15" drill="0.8" shape="long"/>
-<pad name="D13" x="16.51" y="26.67" drill="0.8" shape="long"/>
-<pad name="A0" x="16.51" y="29.21" drill="0.8" shape="long"/>
-<pad name="A1" x="16.51" y="31.75" drill="0.8" shape="long"/>
-<pad name="A2" x="16.51" y="34.29" drill="0.8" shape="long"/>
-<pad name="A3" x="16.51" y="36.83" drill="0.8" shape="long"/>
-<pad name="A4" x="16.51" y="39.37" drill="0.8" shape="long"/>
-<pad name="A5" x="16.51" y="41.91" drill="0.8" shape="long"/>
-<pad name="A6" x="16.51" y="44.45" drill="0.8" shape="long"/>
-<pad name="A7" x="16.51" y="46.99" drill="0.8" shape="long"/>
-<pad name="A8" x="16.51" y="49.53" drill="0.8" shape="long"/>
-<pad name="D12" x="1.27" y="26.67" drill="0.8" shape="long"/>
-<pad name="D11" x="1.27" y="29.21" drill="0.8" shape="long"/>
-<pad name="D5" x="1.27" y="44.45" drill="0.8" shape="long"/>
-<pad name="D4(CANRX)" x="1.27" y="46.99" drill="0.8" shape="long"/>
-<pad name="D3(CANTX)" x="1.27" y="49.53" drill="0.8" shape="long"/>
-<pad name="D2" x="1.27" y="52.07" drill="0.8" shape="long"/>
-<pad name="GND" x="1.27" y="59.69" drill="0.8" shape="long"/>
-<pad name="VIN" x="16.51" y="59.69" drill="0.8" shape="long"/>
-<pad name="3.3V3" x="16.51" y="54.61" drill="0.8" shape="long"/>
-<pad name="A9" x="16.51" y="52.07" drill="0.8" shape="long"/>
-<pad name="D0(RX1)" x="1.27" y="57.15" drill="0.8" shape="long" rot="R180"/>
-<pad name="D1(TX1)" x="1.27" y="54.61" drill="0.8" shape="long" rot="R180"/>
-<pad name="D10(TX2)" x="1.27" y="31.75" drill="0.8" shape="long"/>
-<pad name="D6" x="1.27" y="41.91" drill="0.8" shape="long" rot="R180"/>
-<pad name="D7(RX3)" x="1.27" y="39.37" drill="0.8" shape="long" rot="R180"/>
-<pad name="D8(TX3)" x="1.27" y="36.83" drill="0.8" shape="long" rot="R180"/>
-<pad name="D9(RX2)" x="1.27" y="34.29" drill="0.8" shape="long" rot="R180"/>
-<wire x1="17.78" y1="60.96" x2="17.78" y2="0" width="0.127" layer="21"/>
-<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
-<wire x1="0" y1="0" x2="0" y2="60.96" width="0.127" layer="21"/>
-<wire x1="5.08" y1="61.722" x2="12.7" y2="61.722" width="0.127" layer="21"/>
-<wire x1="12.7" y1="61.722" x2="12.7" y2="60.96" width="0.127" layer="21"/>
-<wire x1="5.08" y1="60.96" x2="5.08" y2="61.722" width="0.127" layer="21"/>
-<wire x1="0" y1="60.96" x2="5.08" y2="60.96" width="0.127" layer="21"/>
-<wire x1="12.7" y1="60.96" x2="17.78" y2="60.96" width="0.127" layer="21"/>
-<wire x1="5.08" y1="60.96" x2="5.08" y2="55.88" width="0.127" layer="21"/>
-<wire x1="5.08" y1="55.88" x2="12.7" y2="55.88" width="0.127" layer="21"/>
-<wire x1="12.7" y1="55.88" x2="12.7" y2="60.96" width="0.127" layer="21"/>
-<pad name="3.3V" x="1.27" y="24.13" drill="0.8" shape="long"/>
-<pad name="D24" x="1.27" y="21.59" drill="0.8" shape="long"/>
-<pad name="D25" x="1.27" y="19.05" drill="0.8" shape="long"/>
-<pad name="D26" x="1.27" y="16.51" drill="0.8" shape="long"/>
-<pad name="D27" x="1.27" y="13.97" drill="0.8" shape="long"/>
-<pad name="D28" x="1.27" y="11.43" drill="0.8" shape="long"/>
-<pad name="D29" x="1.27" y="8.89" drill="0.8" shape="long"/>
-<pad name="D30" x="1.27" y="6.35" drill="0.8" shape="long"/>
-<pad name="A12" x="1.27" y="3.81" drill="0.8" shape="long"/>
-<pad name="A13" x="1.27" y="1.27" drill="0.8" shape="long"/>
-<pad name="GND3" x="16.51" y="24.13" drill="0.8" shape="long"/>
-<pad name="A22" x="16.51" y="21.59" drill="0.8" shape="long"/>
-<pad name="A21" x="16.51" y="19.05" drill="0.8" shape="long"/>
-<pad name="A20" x="16.51" y="16.51" drill="0.8" shape="long"/>
-<pad name="A19" x="16.51" y="13.97" drill="0.8" shape="long"/>
-<pad name="A18" x="16.51" y="11.43" drill="0.8" shape="long"/>
-<pad name="A17" x="16.51" y="8.89" drill="0.8" shape="long"/>
-<pad name="A16" x="16.51" y="6.35" drill="0.8" shape="long"/>
-<pad name="A15" x="16.51" y="3.81" drill="0.8" shape="long"/>
-<pad name="A14" x="16.51" y="1.27" drill="0.8" shape="long"/>
-<pad name="VBAT" x="3.81" y="13.97" drill="0.8" shape="long" rot="R90"/>
-<pad name="3.3V2" x="6.35" y="13.97" drill="0.8" shape="long" rot="R90"/>
-<pad name="GND2" x="8.89" y="13.97" drill="0.8" shape="long" rot="R90"/>
-<pad name="PRGM" x="11.43" y="13.97" drill="0.8" shape="long" rot="R90"/>
-<pad name="RST" x="13.97" y="13.97" drill="0.8" shape="long" rot="R90"/>
-<text x="8.89" y="58.7375" size="2.54" layer="21" align="center">3.6</text>
-</package>
-<package name="TEENSY_LC_EXT">
-<pad name="AGND" x="16.51" y="31.75" drill="0.8" shape="long"/>
-<pad name="D13" x="16.51" y="1.27" drill="0.8" shape="long"/>
-<pad name="A0" x="16.51" y="3.81" drill="0.8" shape="long"/>
-<pad name="A1" x="16.51" y="6.35" drill="0.8" shape="long"/>
-<pad name="A2" x="16.51" y="8.89" drill="0.8" shape="long"/>
-<pad name="A3" x="16.51" y="11.43" drill="0.8" shape="long"/>
-<pad name="A4" x="16.51" y="13.97" drill="0.8" shape="long"/>
-<pad name="A5" x="16.51" y="16.51" drill="0.8" shape="long"/>
-<pad name="A6" x="16.51" y="19.05" drill="0.8" shape="long"/>
-<pad name="A7" x="16.51" y="21.59" drill="0.8" shape="long"/>
-<pad name="A8" x="16.51" y="24.13" drill="0.8" shape="long"/>
-<pad name="D12" x="1.27" y="1.27" drill="0.8" shape="long"/>
-<pad name="D11" x="1.27" y="3.81" drill="0.8" shape="long"/>
-<pad name="D5" x="1.27" y="19.05" drill="0.8" shape="long"/>
-<pad name="D4" x="1.27" y="21.59" drill="0.8" shape="long"/>
-<pad name="D3" x="1.27" y="24.13" drill="0.8" shape="long"/>
-<pad name="D2" x="1.27" y="26.67" drill="0.8" shape="long"/>
-<pad name="GND" x="1.27" y="34.29" drill="0.8" shape="long"/>
-<pad name="VIN" x="16.51" y="34.29" drill="0.8" shape="long"/>
-<pad name="3.3V2" x="16.51" y="29.21" drill="0.8" shape="long"/>
-<pad name="A9" x="16.51" y="26.67" drill="0.8" shape="long"/>
-<pad name="D0(RX1)" x="1.27" y="31.75" drill="0.8" shape="long" rot="R180"/>
-<pad name="D1(TX1)" x="1.27" y="29.21" drill="0.8" shape="long" rot="R180"/>
-<pad name="D10(TX2)" x="1.27" y="6.35" drill="0.8" shape="long"/>
-<pad name="D6" x="1.27" y="16.51" drill="0.8" shape="long" rot="R180"/>
-<pad name="D7(RX3)" x="1.27" y="13.97" drill="0.8" shape="long" rot="R180"/>
-<pad name="D8(TX3)" x="1.27" y="11.43" drill="0.8" shape="long" rot="R180"/>
-<pad name="D9(RX2)" x="1.27" y="8.89" drill="0.8" shape="long" rot="R180"/>
-<wire x1="17.78" y1="35.56" x2="17.78" y2="0" width="0.127" layer="21"/>
-<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
-<wire x1="0" y1="0" x2="0" y2="35.56" width="0.127" layer="21"/>
-<wire x1="5.08" y1="36.322" x2="12.7" y2="36.322" width="0.127" layer="21"/>
-<wire x1="12.7" y1="36.322" x2="12.7" y2="35.56" width="0.127" layer="21"/>
-<wire x1="5.08" y1="35.56" x2="5.08" y2="36.322" width="0.127" layer="21"/>
-<wire x1="0" y1="35.56" x2="5.08" y2="35.56" width="0.127" layer="21"/>
-<wire x1="12.7" y1="35.56" x2="17.78" y2="35.56" width="0.127" layer="21"/>
-<wire x1="5.08" y1="35.56" x2="5.08" y2="30.48" width="0.127" layer="21"/>
-<wire x1="5.08" y1="30.48" x2="12.7" y2="30.48" width="0.127" layer="21"/>
-<wire x1="12.7" y1="30.48" x2="12.7" y2="35.56" width="0.127" layer="21"/>
-<pad name="D17" x="3.81" y="1.27" drill="0.8" shape="long" rot="R90"/>
-<pad name="3.3V" x="6.35" y="1.27" drill="0.8" shape="long" rot="R90"/>
-<pad name="GND2" x="8.89" y="1.27" drill="0.8" shape="long" rot="R90"/>
-<pad name="PGRM" x="11.43" y="1.27" drill="0.8" shape="long" rot="R90"/>
-<pad name="DAC" x="13.97" y="1.27" drill="0.8" shape="long" rot="R90"/>
-<text x="9.2075" y="33.3375" size="2.54" layer="21" align="center">LC</text>
-</package>
-<package name="TEENSY_3.5_EXT_RTC">
-<pad name="AGND" x="16.51" y="57.15" drill="0.8" shape="long"/>
-<pad name="D13" x="16.51" y="26.67" drill="0.8" shape="long"/>
-<pad name="A0" x="16.51" y="29.21" drill="0.8" shape="long"/>
-<pad name="A1" x="16.51" y="31.75" drill="0.8" shape="long"/>
-<pad name="A2" x="16.51" y="34.29" drill="0.8" shape="long"/>
-<pad name="A3" x="16.51" y="36.83" drill="0.8" shape="long"/>
-<pad name="A4" x="16.51" y="39.37" drill="0.8" shape="long"/>
-<pad name="A5" x="16.51" y="41.91" drill="0.8" shape="long"/>
-<pad name="A6" x="16.51" y="44.45" drill="0.8" shape="long"/>
-<pad name="A7" x="16.51" y="46.99" drill="0.8" shape="long"/>
-<pad name="A8" x="16.51" y="49.53" drill="0.8" shape="long"/>
-<pad name="D12" x="1.27" y="26.67" drill="0.8" shape="long"/>
-<pad name="D11" x="1.27" y="29.21" drill="0.8" shape="long"/>
-<pad name="D5" x="1.27" y="44.45" drill="0.8" shape="long"/>
-<pad name="D4(CANRX)" x="1.27" y="46.99" drill="0.8" shape="long"/>
-<pad name="D3(CANTX)" x="1.27" y="49.53" drill="0.8" shape="long"/>
-<pad name="D2" x="1.27" y="52.07" drill="0.8" shape="long"/>
-<pad name="GND" x="1.27" y="59.69" drill="0.8" shape="long"/>
-<pad name="VIN" x="16.51" y="59.69" drill="0.8" shape="long"/>
-<pad name="3.3V3" x="16.51" y="54.61" drill="0.8" shape="long"/>
-<pad name="A9" x="16.51" y="52.07" drill="0.8" shape="long"/>
-<pad name="D0(RX1)" x="1.27" y="57.15" drill="0.8" shape="long" rot="R180"/>
-<pad name="D1(TX1)" x="1.27" y="54.61" drill="0.8" shape="long" rot="R180"/>
-<pad name="D10(TX2)" x="1.27" y="31.75" drill="0.8" shape="long"/>
-<pad name="D6" x="1.27" y="41.91" drill="0.8" shape="long" rot="R180"/>
-<pad name="D7(RX3)" x="1.27" y="39.37" drill="0.8" shape="long" rot="R180"/>
-<pad name="D8(TX3)" x="1.27" y="36.83" drill="0.8" shape="long" rot="R180"/>
-<pad name="D9(RX2)" x="1.27" y="34.29" drill="0.8" shape="long" rot="R180"/>
-<wire x1="17.78" y1="60.96" x2="17.78" y2="0" width="0.127" layer="21"/>
-<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
-<wire x1="0" y1="0" x2="0" y2="60.96" width="0.127" layer="21"/>
-<wire x1="5.08" y1="61.722" x2="12.7" y2="61.722" width="0.127" layer="21"/>
-<wire x1="12.7" y1="61.722" x2="12.7" y2="60.96" width="0.127" layer="21"/>
-<wire x1="5.08" y1="60.96" x2="5.08" y2="61.722" width="0.127" layer="21"/>
-<wire x1="0" y1="60.96" x2="5.08" y2="60.96" width="0.127" layer="21"/>
-<wire x1="12.7" y1="60.96" x2="17.78" y2="60.96" width="0.127" layer="21"/>
-<wire x1="5.08" y1="60.96" x2="5.08" y2="55.88" width="0.127" layer="21"/>
-<wire x1="5.08" y1="55.88" x2="12.7" y2="55.88" width="0.127" layer="21"/>
-<wire x1="12.7" y1="55.88" x2="12.7" y2="60.96" width="0.127" layer="21"/>
-<pad name="3.3V" x="1.27" y="24.13" drill="0.8" shape="long"/>
-<pad name="D24" x="1.27" y="21.59" drill="0.8" shape="long"/>
-<pad name="D25" x="1.27" y="19.05" drill="0.8" shape="long"/>
-<pad name="D26" x="1.27" y="16.51" drill="0.8" shape="long"/>
-<pad name="D27" x="1.27" y="13.97" drill="0.8" shape="long"/>
-<pad name="D28" x="1.27" y="11.43" drill="0.8" shape="long"/>
-<pad name="D29" x="1.27" y="8.89" drill="0.8" shape="long"/>
-<pad name="D30" x="1.27" y="6.35" drill="0.8" shape="long"/>
-<pad name="A12" x="1.27" y="3.81" drill="0.8" shape="long"/>
-<pad name="A13" x="1.27" y="1.27" drill="0.8" shape="long"/>
-<pad name="GND3" x="16.51" y="24.13" drill="0.8" shape="long"/>
-<pad name="A22" x="16.51" y="21.59" drill="0.8" shape="long"/>
-<pad name="A21" x="16.51" y="19.05" drill="0.8" shape="long"/>
-<pad name="A20" x="16.51" y="16.51" drill="0.8" shape="long"/>
-<pad name="A19" x="16.51" y="13.97" drill="0.8" shape="long"/>
-<pad name="A18" x="16.51" y="11.43" drill="0.8" shape="long"/>
-<pad name="A17" x="16.51" y="8.89" drill="0.8" shape="long"/>
-<pad name="A16" x="16.51" y="6.35" drill="0.8" shape="long"/>
-<pad name="A15" x="16.51" y="3.81" drill="0.8" shape="long"/>
-<pad name="A14" x="16.51" y="1.27" drill="0.8" shape="long"/>
-<pad name="VBAT" x="3.81" y="13.97" drill="0.8" shape="long" rot="R90"/>
-<pad name="3.3V2" x="6.35" y="13.97" drill="0.8" shape="long" rot="R90"/>
-<pad name="GND2" x="8.89" y="13.97" drill="0.8" shape="long" rot="R90"/>
-<pad name="PRGM" x="11.43" y="13.97" drill="0.8" shape="long" rot="R90"/>
-<pad name="RST" x="13.97" y="13.97" drill="0.8" shape="long" rot="R90"/>
-<text x="8.89" y="58.7375" size="2.54" layer="21" align="center">3.5</text>
-</package>
-<package name="TEENSY_3.5_SIMPLE">
-<pad name="AGND" x="16.51" y="57.15" drill="0.8" shape="long"/>
-<pad name="D13" x="16.51" y="26.67" drill="0.8" shape="long"/>
-<pad name="A0" x="16.51" y="29.21" drill="0.8" shape="long"/>
-<pad name="A1" x="16.51" y="31.75" drill="0.8" shape="long"/>
-<pad name="A2" x="16.51" y="34.29" drill="0.8" shape="long"/>
-<pad name="A3" x="16.51" y="36.83" drill="0.8" shape="long"/>
-<pad name="A4" x="16.51" y="39.37" drill="0.8" shape="long"/>
-<pad name="A5" x="16.51" y="41.91" drill="0.8" shape="long"/>
-<pad name="A6" x="16.51" y="44.45" drill="0.8" shape="long"/>
-<pad name="A7" x="16.51" y="46.99" drill="0.8" shape="long"/>
-<pad name="A8" x="16.51" y="49.53" drill="0.8" shape="long"/>
-<pad name="D12" x="1.27" y="26.67" drill="0.8" shape="long"/>
-<pad name="D11" x="1.27" y="29.21" drill="0.8" shape="long"/>
-<pad name="D5" x="1.27" y="44.45" drill="0.8" shape="long"/>
-<pad name="D4(CANRX)" x="1.27" y="46.99" drill="0.8" shape="long"/>
-<pad name="D3(CANTX)" x="1.27" y="49.53" drill="0.8" shape="long"/>
-<pad name="D2" x="1.27" y="52.07" drill="0.8" shape="long"/>
-<pad name="GND" x="1.27" y="59.69" drill="0.8" shape="long"/>
-<pad name="VIN" x="16.51" y="59.69" drill="0.8" shape="long"/>
-<pad name="3.3V2" x="16.51" y="54.61" drill="0.8" shape="long"/>
-<pad name="A9" x="16.51" y="52.07" drill="0.8" shape="long"/>
-<pad name="D0(RX1)" x="1.27" y="57.15" drill="0.8" shape="long" rot="R180"/>
-<pad name="D1(TX1)" x="1.27" y="54.61" drill="0.8" shape="long" rot="R180"/>
-<pad name="D10(TX2)" x="1.27" y="31.75" drill="0.8" shape="long"/>
-<pad name="D6" x="1.27" y="41.91" drill="0.8" shape="long" rot="R180"/>
-<pad name="D7(RX3)" x="1.27" y="39.37" drill="0.8" shape="long" rot="R180"/>
-<pad name="D8(TX3)" x="1.27" y="36.83" drill="0.8" shape="long" rot="R180"/>
-<pad name="D9(RX2)" x="1.27" y="34.29" drill="0.8" shape="long" rot="R180"/>
-<wire x1="17.78" y1="60.96" x2="17.78" y2="0" width="0.127" layer="21"/>
-<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
-<wire x1="0" y1="0" x2="0" y2="60.96" width="0.127" layer="21"/>
-<wire x1="5.08" y1="61.722" x2="12.7" y2="61.722" width="0.127" layer="21"/>
-<wire x1="12.7" y1="61.722" x2="12.7" y2="60.96" width="0.127" layer="21"/>
-<wire x1="5.08" y1="60.96" x2="5.08" y2="61.722" width="0.127" layer="21"/>
-<wire x1="0" y1="60.96" x2="5.08" y2="60.96" width="0.127" layer="21"/>
-<wire x1="12.7" y1="60.96" x2="17.78" y2="60.96" width="0.127" layer="21"/>
-<wire x1="5.08" y1="60.96" x2="5.08" y2="55.88" width="0.127" layer="21"/>
-<wire x1="5.08" y1="55.88" x2="12.7" y2="55.88" width="0.127" layer="21"/>
-<wire x1="12.7" y1="55.88" x2="12.7" y2="60.96" width="0.127" layer="21"/>
-<pad name="3.3V" x="1.27" y="24.13" drill="0.8" shape="long"/>
-<pad name="D24" x="1.27" y="21.59" drill="0.8" shape="long"/>
-<pad name="D25" x="1.27" y="19.05" drill="0.8" shape="long"/>
-<pad name="D26" x="1.27" y="16.51" drill="0.8" shape="long"/>
-<pad name="D27" x="1.27" y="13.97" drill="0.8" shape="long"/>
-<pad name="D28" x="1.27" y="11.43" drill="0.8" shape="long"/>
-<pad name="D29" x="1.27" y="8.89" drill="0.8" shape="long"/>
-<pad name="D30" x="1.27" y="6.35" drill="0.8" shape="long"/>
-<pad name="A12" x="1.27" y="3.81" drill="0.8" shape="long"/>
-<pad name="A13" x="1.27" y="1.27" drill="0.8" shape="long"/>
-<pad name="GND2" x="16.51" y="24.13" drill="0.8" shape="long"/>
-<pad name="A22" x="16.51" y="21.59" drill="0.8" shape="long"/>
-<pad name="A21" x="16.51" y="19.05" drill="0.8" shape="long"/>
-<pad name="A20" x="16.51" y="16.51" drill="0.8" shape="long"/>
-<pad name="A19" x="16.51" y="13.97" drill="0.8" shape="long"/>
-<pad name="A18" x="16.51" y="11.43" drill="0.8" shape="long"/>
-<pad name="A17" x="16.51" y="8.89" drill="0.8" shape="long"/>
-<pad name="A16" x="16.51" y="6.35" drill="0.8" shape="long"/>
-<pad name="A15" x="16.51" y="3.81" drill="0.8" shape="long"/>
-<pad name="A14" x="16.51" y="1.27" drill="0.8" shape="long"/>
-<text x="8.89" y="58.7375" size="2.54" layer="21" align="center">3.5</text>
-</package>
-<package name="TEENSY_3.6_SIMPLE">
-<pad name="AGND" x="16.51" y="57.15" drill="0.8" shape="long"/>
-<pad name="D13" x="16.51" y="26.67" drill="0.8" shape="long"/>
-<pad name="A0" x="16.51" y="29.21" drill="0.8" shape="long"/>
-<pad name="A1" x="16.51" y="31.75" drill="0.8" shape="long"/>
-<pad name="A2" x="16.51" y="34.29" drill="0.8" shape="long"/>
-<pad name="A3" x="16.51" y="36.83" drill="0.8" shape="long"/>
-<pad name="A4" x="16.51" y="39.37" drill="0.8" shape="long"/>
-<pad name="A5" x="16.51" y="41.91" drill="0.8" shape="long"/>
-<pad name="A6" x="16.51" y="44.45" drill="0.8" shape="long"/>
-<pad name="A7" x="16.51" y="46.99" drill="0.8" shape="long"/>
-<pad name="A8" x="16.51" y="49.53" drill="0.8" shape="long"/>
-<pad name="D12" x="1.27" y="26.67" drill="0.8" shape="long"/>
-<pad name="D11" x="1.27" y="29.21" drill="0.8" shape="long"/>
-<pad name="D5" x="1.27" y="44.45" drill="0.8" shape="long"/>
-<pad name="D4(CANRX)" x="1.27" y="46.99" drill="0.8" shape="long"/>
-<pad name="D3(CANTX)" x="1.27" y="49.53" drill="0.8" shape="long"/>
-<pad name="D2" x="1.27" y="52.07" drill="0.8" shape="long"/>
-<pad name="GND" x="1.27" y="59.69" drill="0.8" shape="long"/>
-<pad name="VIN" x="16.51" y="59.69" drill="0.8" shape="long"/>
-<pad name="3.3V2" x="16.51" y="54.61" drill="0.8" shape="long"/>
-<pad name="A9" x="16.51" y="52.07" drill="0.8" shape="long"/>
-<pad name="D0(RX1)" x="1.27" y="57.15" drill="0.8" shape="long" rot="R180"/>
-<pad name="D1(TX1)" x="1.27" y="54.61" drill="0.8" shape="long" rot="R180"/>
-<pad name="D10(TX2)" x="1.27" y="31.75" drill="0.8" shape="long"/>
-<pad name="D6" x="1.27" y="41.91" drill="0.8" shape="long" rot="R180"/>
-<pad name="D7(RX3)" x="1.27" y="39.37" drill="0.8" shape="long" rot="R180"/>
-<pad name="D8(TX3)" x="1.27" y="36.83" drill="0.8" shape="long" rot="R180"/>
-<pad name="D9(RX2)" x="1.27" y="34.29" drill="0.8" shape="long" rot="R180"/>
-<wire x1="17.78" y1="60.96" x2="17.78" y2="0" width="0.127" layer="21"/>
-<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
-<wire x1="0" y1="0" x2="0" y2="60.96" width="0.127" layer="21"/>
-<wire x1="5.08" y1="61.722" x2="12.7" y2="61.722" width="0.127" layer="21"/>
-<wire x1="12.7" y1="61.722" x2="12.7" y2="60.96" width="0.127" layer="21"/>
-<wire x1="5.08" y1="60.96" x2="5.08" y2="61.722" width="0.127" layer="21"/>
-<wire x1="0" y1="60.96" x2="5.08" y2="60.96" width="0.127" layer="21"/>
-<wire x1="12.7" y1="60.96" x2="17.78" y2="60.96" width="0.127" layer="21"/>
-<wire x1="5.08" y1="60.96" x2="5.08" y2="55.88" width="0.127" layer="21"/>
-<wire x1="5.08" y1="55.88" x2="12.7" y2="55.88" width="0.127" layer="21"/>
-<wire x1="12.7" y1="55.88" x2="12.7" y2="60.96" width="0.127" layer="21"/>
-<pad name="3.3V" x="1.27" y="24.13" drill="0.8" shape="long"/>
-<pad name="D24" x="1.27" y="21.59" drill="0.8" shape="long"/>
-<pad name="D25" x="1.27" y="19.05" drill="0.8" shape="long"/>
-<pad name="D26" x="1.27" y="16.51" drill="0.8" shape="long"/>
-<pad name="D27" x="1.27" y="13.97" drill="0.8" shape="long"/>
-<pad name="D28" x="1.27" y="11.43" drill="0.8" shape="long"/>
-<pad name="D29" x="1.27" y="8.89" drill="0.8" shape="long"/>
-<pad name="D30" x="1.27" y="6.35" drill="0.8" shape="long"/>
-<pad name="A12" x="1.27" y="3.81" drill="0.8" shape="long"/>
-<pad name="A13" x="1.27" y="1.27" drill="0.8" shape="long"/>
-<pad name="GND2" x="16.51" y="24.13" drill="0.8" shape="long"/>
-<pad name="A22" x="16.51" y="21.59" drill="0.8" shape="long"/>
-<pad name="A21" x="16.51" y="19.05" drill="0.8" shape="long"/>
-<pad name="A20" x="16.51" y="16.51" drill="0.8" shape="long"/>
-<pad name="A19" x="16.51" y="13.97" drill="0.8" shape="long"/>
-<pad name="A18" x="16.51" y="11.43" drill="0.8" shape="long"/>
-<pad name="A17" x="16.51" y="8.89" drill="0.8" shape="long"/>
-<pad name="A16" x="16.51" y="6.35" drill="0.8" shape="long"/>
-<pad name="A15" x="16.51" y="3.81" drill="0.8" shape="long"/>
-<pad name="A14" x="16.51" y="1.27" drill="0.8" shape="long"/>
-<text x="8.89" y="58.7375" size="2.54" layer="21" align="center">3.6</text>
-</package>
-<package name="TEENSY_LC_SIMPLE">
-<pad name="AGND" x="16.51" y="31.75" drill="0.8" shape="long"/>
-<pad name="D13" x="16.51" y="1.27" drill="0.8" shape="long"/>
-<pad name="A0" x="16.51" y="3.81" drill="0.8" shape="long"/>
-<pad name="A1" x="16.51" y="6.35" drill="0.8" shape="long"/>
-<pad name="A2" x="16.51" y="8.89" drill="0.8" shape="long"/>
-<pad name="A3" x="16.51" y="11.43" drill="0.8" shape="long"/>
-<pad name="A4" x="16.51" y="13.97" drill="0.8" shape="long"/>
-<pad name="A5" x="16.51" y="16.51" drill="0.8" shape="long"/>
-<pad name="A6" x="16.51" y="19.05" drill="0.8" shape="long"/>
-<pad name="A7" x="16.51" y="21.59" drill="0.8" shape="long"/>
-<pad name="A8" x="16.51" y="24.13" drill="0.8" shape="long"/>
-<pad name="D12" x="1.27" y="1.27" drill="0.8" shape="long"/>
-<pad name="D11" x="1.27" y="3.81" drill="0.8" shape="long"/>
-<pad name="D5" x="1.27" y="19.05" drill="0.8" shape="long"/>
-<pad name="D4" x="1.27" y="21.59" drill="0.8" shape="long"/>
-<pad name="D3" x="1.27" y="24.13" drill="0.8" shape="long"/>
-<pad name="D2" x="1.27" y="26.67" drill="0.8" shape="long"/>
-<pad name="GND" x="1.27" y="34.29" drill="0.8" shape="long"/>
-<pad name="VIN" x="16.51" y="34.29" drill="0.8" shape="long"/>
-<pad name="3.3V" x="16.51" y="29.21" drill="0.8" shape="long"/>
-<pad name="A9" x="16.51" y="26.67" drill="0.8" shape="long"/>
-<pad name="D0(RX1)" x="1.27" y="31.75" drill="0.8" shape="long" rot="R180"/>
-<pad name="D1(TX1)" x="1.27" y="29.21" drill="0.8" shape="long" rot="R180"/>
-<pad name="D10(TX2)" x="1.27" y="6.35" drill="0.8" shape="long"/>
-<pad name="D6" x="1.27" y="16.51" drill="0.8" shape="long" rot="R180"/>
-<pad name="D7(RX3)" x="1.27" y="13.97" drill="0.8" shape="long" rot="R180"/>
-<pad name="D8(TX3)" x="1.27" y="11.43" drill="0.8" shape="long" rot="R180"/>
-<pad name="D9(RX2)" x="1.27" y="8.89" drill="0.8" shape="long" rot="R180"/>
-<wire x1="17.78" y1="35.56" x2="17.78" y2="0" width="0.127" layer="21"/>
-<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
-<wire x1="0" y1="0" x2="0" y2="35.56" width="0.127" layer="21"/>
-<wire x1="5.08" y1="36.322" x2="12.7" y2="36.322" width="0.127" layer="21"/>
-<wire x1="12.7" y1="36.322" x2="12.7" y2="35.56" width="0.127" layer="21"/>
-<wire x1="5.08" y1="35.56" x2="5.08" y2="36.322" width="0.127" layer="21"/>
-<wire x1="0" y1="35.56" x2="5.08" y2="35.56" width="0.127" layer="21"/>
-<wire x1="12.7" y1="35.56" x2="17.78" y2="35.56" width="0.127" layer="21"/>
-<wire x1="5.08" y1="35.56" x2="5.08" y2="30.48" width="0.127" layer="21"/>
-<wire x1="5.08" y1="30.48" x2="12.7" y2="30.48" width="0.127" layer="21"/>
-<wire x1="12.7" y1="30.48" x2="12.7" y2="35.56" width="0.127" layer="21"/>
-<text x="9.2075" y="33.3375" size="2.54" layer="21" align="center">LC</text>
-</package>
 <package name="OKI-78SR-H">
 <pad name="1" x="2.54" y="0" drill="1" diameter="1.8796" shape="square"/>
 <pad name="2" x="0" y="0" drill="1" diameter="1.8796"/>
@@ -10378,173 +10035,147 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <wire x1="-2" y1="-1.6" x2="-2" y2="1.6" width="0.127" layer="21"/>
 <text x="-2.1" y="1.9" size="1.27" layer="21">&gt;NAME</text>
 </package>
-<package name="MSOP-8_MS">
-<smd name="1" x="-2.2098" y="0.975" dx="1.397" dy="0.4318" layer="1"/>
-<smd name="2" x="-2.2098" y="0.325" dx="1.397" dy="0.4318" layer="1"/>
-<smd name="3" x="-2.2098" y="-0.325" dx="1.397" dy="0.4318" layer="1"/>
-<smd name="4" x="-2.2098" y="-0.975" dx="1.397" dy="0.4318" layer="1"/>
-<smd name="5" x="2.2098" y="-0.975" dx="1.397" dy="0.4318" layer="1"/>
-<smd name="6" x="2.2098" y="-0.325" dx="1.397" dy="0.4318" layer="1"/>
-<smd name="7" x="2.2098" y="0.325" dx="1.397" dy="0.4318" layer="1"/>
-<smd name="8" x="2.2098" y="0.975" dx="1.397" dy="0.4318" layer="1"/>
-<wire x1="-1.5494" y1="0.7874" x2="-1.5494" y2="1.1684" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="1.1684" x2="-2.54" y2="1.1684" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="1.1684" x2="-2.54" y2="0.7874" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="0.7874" x2="-1.5494" y2="0.7874" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="0.127" x2="-1.5494" y2="0.508" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="0.508" x2="-2.54" y2="0.508" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="0.508" x2="-2.54" y2="0.127" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="0.127" x2="-1.5494" y2="0.127" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="-0.508" x2="-1.5494" y2="-0.127" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="-0.127" x2="-2.54" y2="-0.127" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="-0.127" x2="-2.54" y2="-0.508" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="-0.508" x2="-1.5494" y2="-0.508" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="-1.1684" x2="-1.5494" y2="-0.7874" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="-0.7874" x2="-2.54" y2="-0.7874" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="-0.7874" x2="-2.54" y2="-1.1684" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="-1.1684" x2="-1.5494" y2="-1.1684" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="-0.7874" x2="1.5494" y2="-1.1684" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="-1.1684" x2="2.54" y2="-1.1684" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="-1.1684" x2="2.54" y2="-0.7874" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="-0.7874" x2="1.5494" y2="-0.7874" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="-0.127" x2="1.5494" y2="-0.508" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="-0.508" x2="2.54" y2="-0.508" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="-0.508" x2="2.54" y2="-0.127" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="-0.127" x2="1.5494" y2="-0.127" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="0.508" x2="1.5494" y2="0.127" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="0.127" x2="2.54" y2="0.127" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="0.127" x2="2.54" y2="0.508" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="0.508" x2="1.5494" y2="0.508" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="1.1684" x2="1.5494" y2="0.7874" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="0.7874" x2="2.54" y2="0.7874" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="0.7874" x2="2.54" y2="1.1684" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="1.1684" x2="1.5494" y2="1.1684" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="-1.5494" x2="1.5494" y2="-1.5494" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="-1.5494" x2="1.5494" y2="1.5494" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="1.5494" x2="0.3048" y2="1.5494" width="0.1524" layer="51"/>
-<wire x1="0.3048" y1="1.5494" x2="-0.3048" y2="1.5494" width="0.1524" layer="51"/>
-<wire x1="-0.3048" y1="1.5494" x2="-1.5494" y2="1.5494" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="1.5494" x2="-1.5494" y2="-1.5494" width="0.1524" layer="51"/>
-<wire x1="0.3048" y1="1.5494" x2="-0.3048" y2="1.5494" width="0.1524" layer="51" curve="-180"/>
-<text x="-1.7526" y="0.2032" size="1.27" layer="51" ratio="6" rot="SR0">*</text>
-<wire x1="-3.1496" y1="-1.4478" x2="-3.1496" y2="1.4478" width="0.1524" layer="39"/>
-<wire x1="-3.1496" y1="1.4478" x2="-1.8034" y2="1.4478" width="0.1524" layer="39"/>
-<wire x1="-1.8034" y1="1.4478" x2="-1.8034" y2="1.8034" width="0.1524" layer="39"/>
-<wire x1="-1.8034" y1="1.8034" x2="1.8034" y2="1.8034" width="0.1524" layer="39"/>
-<wire x1="1.8034" y1="1.8034" x2="1.8034" y2="1.4478" width="0.1524" layer="39"/>
-<wire x1="3.1496" y1="1.4478" x2="1.8034" y2="1.4478" width="0.1524" layer="39"/>
-<wire x1="3.1496" y1="1.4478" x2="3.1496" y2="-1.4478" width="0.1524" layer="39"/>
-<wire x1="3.1496" y1="-1.4478" x2="1.8034" y2="-1.4478" width="0.1524" layer="39"/>
-<wire x1="1.8034" y1="-1.4478" x2="1.8034" y2="-1.8034" width="0.1524" layer="39"/>
-<wire x1="1.8034" y1="-1.8034" x2="-1.8034" y2="-1.8034" width="0.1524" layer="39"/>
-<wire x1="-1.8034" y1="-1.8034" x2="-1.8034" y2="-1.4478" width="0.1524" layer="39"/>
-<wire x1="-3.1496" y1="-1.4478" x2="-1.8034" y2="-1.4478" width="0.1524" layer="39"/>
-<polygon width="0.1524" layer="39">
-<vertex x="-3.1623" y="-1.4449"/>
-<vertex x="-3.1623" y="1.4449"/>
-<vertex x="-1.8034" y="1.4449"/>
-<vertex x="-1.8034" y="1.8034"/>
-<vertex x="1.8034" y="1.8034"/>
-<vertex x="1.8034" y="1.4449"/>
-<vertex x="3.1623" y="1.4449"/>
-<vertex x="3.1623" y="-1.4449"/>
-<vertex x="1.8034" y="-1.4449"/>
-<vertex x="1.8034" y="-1.8034"/>
-<vertex x="-1.8034" y="-1.8034"/>
-<vertex x="-1.8034" y="-1.4449"/>
-</polygon>
-<wire x1="-1.6764" y1="-1.6764" x2="1.6764" y2="-1.6764" width="0.1524" layer="21"/>
-<wire x1="1.6764" y1="-1.6764" x2="1.6764" y2="-1.524" width="0.1524" layer="21"/>
-<wire x1="1.6764" y1="1.6764" x2="-1.6764" y2="1.6764" width="0.1524" layer="21"/>
-<wire x1="-1.6764" y1="1.6764" x2="-1.6764" y2="1.524" width="0.1524" layer="21"/>
-<wire x1="-1.6764" y1="-1.524" x2="-1.6764" y2="-1.6764" width="0.1524" layer="21"/>
-<wire x1="1.6764" y1="1.524" x2="1.6764" y2="1.6764" width="0.1524" layer="21"/>
-<text x="-3.048" y="1.27" size="1.27" layer="21" ratio="6" rot="SR0">*</text>
-<wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
-<wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
-<text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+<package name="LTC6811">
+<smd name="8" x="-2.25" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="9" x="-1.75" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="10" x="-1.25" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="11" x="-0.75" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="12" x="-0.25" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="13" x="0.25" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="14" x="0.75" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="15" x="1.25" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="16" x="1.75" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="17" x="2.25" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="18" x="2.75" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="19" x="3.25" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="20" x="3.75" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="21" x="4.25" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="22" x="4.75" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="23" x="5.25" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="24" x="5.75" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="7" x="-2.75" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="6" x="-3.25" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="5" x="-3.75" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="4" x="-4.25" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="3" x="-4.75" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="2" x="-5.25" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="1" x="-5.75" y="-3.37" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="25" x="5.75" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="26" x="5.25" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="27" x="4.75" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="28" x="4.25" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="29" x="3.75" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="30" x="3.25" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="31" x="2.75" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="32" x="2.25" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="33" x="1.75" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="34" x="1.25" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="35" x="0.75" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="36" x="0.25" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="37" x="-0.25" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="38" x="-0.75" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="39" x="-1.25" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="40" x="-1.75" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="41" x="-2.25" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="42" x="-2.75" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="43" x="-3.25" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="44" x="-3.75" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="45" x="-4.25" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="46" x="-4.75" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="47" x="-5.25" y="3.38" dx="0.25" dy="1.25" layer="1" rot="R180"/>
+<smd name="48" x="-5.75" y="3.38" dx="0.25" dy="1.25" layer="1"/>
+<circle x="-5.664" y="-1.985" radius="0.127" width="0.254" layer="21"/>
+<wire x1="-6.35" y1="2.75" x2="6.35" y2="2.75" width="0.1524" layer="21"/>
+<wire x1="-6.35" y1="-2.75" x2="6.35" y2="-2.75" width="0.1524" layer="21"/>
+<wire x1="-6.35" y1="-2.75" x2="-6.35" y2="2.75" width="0.1524" layer="21"/>
+<wire x1="6.35" y1="-2.75" x2="6.35" y2="2.75" width="0.1524" layer="21"/>
+<text x="0" y="0" size="1.016" layer="21" align="center">LTC6811</text>
 </package>
-<package name="MSOP-8_MS-M">
-<smd name="1" x="-2.2606" y="0.975" dx="1.7018" dy="0.4826" layer="1"/>
-<smd name="2" x="-2.2606" y="0.325" dx="1.7018" dy="0.4826" layer="1"/>
-<smd name="3" x="-2.2606" y="-0.325" dx="1.7018" dy="0.4826" layer="1"/>
-<smd name="4" x="-2.2606" y="-0.975" dx="1.7018" dy="0.4826" layer="1"/>
-<smd name="5" x="2.2606" y="-0.975" dx="1.7018" dy="0.4826" layer="1"/>
-<smd name="6" x="2.2606" y="-0.325" dx="1.7018" dy="0.4826" layer="1"/>
-<smd name="7" x="2.2606" y="0.325" dx="1.7018" dy="0.4826" layer="1"/>
-<smd name="8" x="2.2606" y="0.975" dx="1.7018" dy="0.4826" layer="1"/>
-<wire x1="-1.5494" y1="0.7874" x2="-1.5494" y2="1.1684" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="1.1684" x2="-2.54" y2="1.1684" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="1.1684" x2="-2.54" y2="0.7874" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="0.7874" x2="-1.5494" y2="0.7874" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="0.127" x2="-1.5494" y2="0.508" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="0.508" x2="-2.54" y2="0.508" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="0.508" x2="-2.54" y2="0.127" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="0.127" x2="-1.5494" y2="0.127" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="-0.508" x2="-1.5494" y2="-0.127" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="-0.127" x2="-2.54" y2="-0.127" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="-0.127" x2="-2.54" y2="-0.508" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="-0.508" x2="-1.5494" y2="-0.508" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="-1.1684" x2="-1.5494" y2="-0.7874" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="-0.7874" x2="-2.54" y2="-0.7874" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="-0.7874" x2="-2.54" y2="-1.1684" width="0.1524" layer="51"/>
-<wire x1="-2.54" y1="-1.1684" x2="-1.5494" y2="-1.1684" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="-0.7874" x2="1.5494" y2="-1.1684" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="-1.1684" x2="2.54" y2="-1.1684" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="-1.1684" x2="2.54" y2="-0.7874" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="-0.7874" x2="1.5494" y2="-0.7874" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="-0.127" x2="1.5494" y2="-0.508" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="-0.508" x2="2.54" y2="-0.508" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="-0.508" x2="2.54" y2="-0.127" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="-0.127" x2="1.5494" y2="-0.127" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="0.508" x2="1.5494" y2="0.127" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="0.127" x2="2.54" y2="0.127" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="0.127" x2="2.54" y2="0.508" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="0.508" x2="1.5494" y2="0.508" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="1.1684" x2="1.5494" y2="0.7874" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="0.7874" x2="2.54" y2="0.7874" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="0.7874" x2="2.54" y2="1.1684" width="0.1524" layer="51"/>
-<wire x1="2.54" y1="1.1684" x2="1.5494" y2="1.1684" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="-1.5494" x2="1.5494" y2="-1.5494" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="-1.5494" x2="1.5494" y2="1.5494" width="0.1524" layer="51"/>
-<wire x1="1.5494" y1="1.5494" x2="0.3048" y2="1.5494" width="0.1524" layer="51"/>
-<wire x1="0.3048" y1="1.5494" x2="-0.3048" y2="1.5494" width="0.1524" layer="51"/>
-<wire x1="-0.3048" y1="1.5494" x2="-1.5494" y2="1.5494" width="0.1524" layer="51"/>
-<wire x1="-1.5494" y1="1.5494" x2="-1.5494" y2="-1.5494" width="0.1524" layer="51"/>
-<wire x1="0.3048" y1="1.5494" x2="-0.3048" y2="1.5494" width="0.1524" layer="51" curve="-180"/>
-<text x="-1.7526" y="0.2032" size="1.27" layer="51" ratio="6" rot="SR0">*</text>
-<wire x1="-3.6068" y1="-1.7272" x2="-3.6068" y2="1.7272" width="0.1524" layer="39"/>
-<wire x1="-3.6068" y1="1.7272" x2="-2.0574" y2="1.7272" width="0.1524" layer="39"/>
-<wire x1="-2.0574" y1="1.7272" x2="-2.0574" y2="2.0574" width="0.1524" layer="39"/>
-<wire x1="-2.0574" y1="2.0574" x2="2.0574" y2="2.0574" width="0.1524" layer="39"/>
-<wire x1="2.0574" y1="2.0574" x2="2.0574" y2="1.7272" width="0.1524" layer="39"/>
-<wire x1="3.6068" y1="1.7272" x2="2.0574" y2="1.7272" width="0.1524" layer="39"/>
-<wire x1="3.6068" y1="1.7272" x2="3.6068" y2="-1.7272" width="0.1524" layer="39"/>
-<wire x1="3.6068" y1="-1.7272" x2="2.0574" y2="-1.7272" width="0.1524" layer="39"/>
-<wire x1="2.0574" y1="-1.7272" x2="2.0574" y2="-2.0574" width="0.1524" layer="39"/>
-<wire x1="2.0574" y1="-2.0574" x2="-2.0574" y2="-2.0574" width="0.1524" layer="39"/>
-<wire x1="-2.0574" y1="-2.0574" x2="-2.0574" y2="-1.7272" width="0.1524" layer="39"/>
-<wire x1="-3.6068" y1="-1.7272" x2="-2.0574" y2="-1.7272" width="0.1524" layer="39"/>
-<polygon width="0.1524" layer="39">
-<vertex x="-3.6195" y="-1.7243"/>
-<vertex x="-3.6195" y="1.7243"/>
-<vertex x="-2.0574" y="1.7243"/>
-<vertex x="-2.0574" y="2.0574"/>
-<vertex x="2.0574" y="2.0574"/>
-<vertex x="2.0574" y="1.7243"/>
-<vertex x="3.6195" y="1.7243"/>
-<vertex x="3.6195" y="-1.7243"/>
-<vertex x="2.0574" y="-1.7243"/>
-<vertex x="2.0574" y="-2.0574"/>
-<vertex x="-2.0574" y="-2.0574"/>
-<vertex x="-2.0574" y="-1.7243"/>
-</polygon>
-<wire x1="-1.6764" y1="-1.6764" x2="1.6764" y2="-1.6764" width="0.1524" layer="21"/>
-<wire x1="1.6764" y1="1.6764" x2="-1.6764" y2="1.6764" width="0.1524" layer="21"/>
-<text x="-3.0988" y="1.3208" size="1.27" layer="21" ratio="6" rot="SR0">*</text>
-<wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
-<wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
-<text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+<package name="TEENSY_3.2_EXT_12ANALOG">
+<pad name="AGND" x="16.51" y="31.75" drill="0.8" shape="long"/>
+<pad name="D13" x="16.51" y="1.27" drill="0.8" shape="long"/>
+<pad name="A0" x="16.51" y="3.81" drill="0.8" shape="long"/>
+<pad name="A1" x="16.51" y="6.35" drill="0.8" shape="long"/>
+<pad name="A2" x="16.51" y="8.89" drill="0.8" shape="long"/>
+<pad name="A3" x="16.51" y="11.43" drill="0.8" shape="long"/>
+<pad name="A4" x="16.51" y="13.97" drill="0.8" shape="long"/>
+<pad name="A5" x="16.51" y="16.51" drill="0.8" shape="long"/>
+<pad name="A6" x="16.51" y="19.05" drill="0.8" shape="long"/>
+<pad name="A7" x="16.51" y="21.59" drill="0.8" diameter="1.778" rot="R180"/>
+<pad name="A8" x="16.51" y="24.13" drill="0.8" diameter="1.778" rot="R180"/>
+<pad name="D12" x="1.27" y="1.27" drill="0.8" shape="long"/>
+<pad name="D11" x="1.27" y="3.81" drill="0.8" shape="long"/>
+<pad name="D5" x="1.27" y="19.05" drill="0.8" shape="long"/>
+<pad name="D4(CANRX)" x="1.27" y="21.59" drill="0.8" shape="long"/>
+<pad name="D3(CANTX)" x="1.27" y="24.13" drill="0.8" shape="long"/>
+<pad name="D2" x="1.27" y="26.67" drill="0.8" shape="long"/>
+<pad name="GND" x="1.27" y="34.29" drill="0.8" shape="long"/>
+<pad name="VIN" x="16.51" y="34.29" drill="0.8" shape="long"/>
+<pad name="3.3V" x="16.51" y="29.21" drill="0.8" shape="long"/>
+<pad name="A9" x="16.51" y="26.67" drill="0.8" shape="long"/>
+<pad name="D0(RX1)" x="1.27" y="31.75" drill="0.8" shape="long" rot="R180"/>
+<pad name="D1(TX1)" x="1.27" y="29.21" drill="0.8" shape="long" rot="R180"/>
+<pad name="D10(TX2)" x="1.27" y="6.35" drill="0.8" shape="long"/>
+<pad name="D6" x="1.27" y="16.51" drill="0.8" shape="long" rot="R180"/>
+<pad name="D7(RX3)" x="1.27" y="13.97" drill="0.8" shape="long" rot="R180"/>
+<pad name="D8(TX3)" x="1.27" y="11.43" drill="0.8" shape="long" rot="R180"/>
+<pad name="D9(RX2)" x="1.27" y="8.89" drill="0.8" shape="long" rot="R180"/>
+<wire x1="17.78" y1="35.56" x2="17.78" y2="0" width="0.127" layer="21"/>
+<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="36.322" x2="12.7" y2="36.322" width="0.127" layer="21"/>
+<wire x1="12.7" y1="36.322" x2="12.7" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="35.56" x2="5.08" y2="36.322" width="0.127" layer="21"/>
+<wire x1="0" y1="35.56" x2="5.08" y2="35.56" width="0.127" layer="21"/>
+<wire x1="12.7" y1="35.56" x2="17.78" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="35.56" x2="5.08" y2="30.48" width="0.127" layer="21"/>
+<wire x1="5.08" y1="30.48" x2="12.7" y2="30.48" width="0.127" layer="21"/>
+<wire x1="12.7" y1="30.48" x2="12.7" y2="35.56" width="0.127" layer="21"/>
+<pad name="A10" x="13.97" y="24.13" drill="0.8" diameter="1.778" rot="R90"/>
+<pad name="A11" x="13.97" y="21.59" drill="0.8" diameter="1.778" rot="R90"/>
+<text x="8.89" y="33.3375" size="2.54" layer="21" align="center">3.2</text>
+</package>
+<package name="TEENSY_4.0_SIMPLE">
+<pad name="GND2" x="16.51" y="31.75" drill="0.8" shape="long"/>
+<pad name="D13" x="16.51" y="1.27" drill="0.8" shape="long"/>
+<pad name="(TX3)A0" x="16.51" y="3.81" drill="0.8" shape="long"/>
+<pad name="(RX3)A1" x="16.51" y="6.35" drill="0.8" shape="long"/>
+<pad name="A2" x="16.51" y="8.89" drill="0.8" shape="long"/>
+<pad name="A3" x="16.51" y="11.43" drill="0.8" shape="long"/>
+<pad name="A4" x="16.51" y="13.97" drill="0.8" shape="long"/>
+<pad name="A5" x="16.51" y="16.51" drill="0.8" shape="long"/>
+<pad name="A6" x="16.51" y="19.05" drill="0.8" shape="long"/>
+<pad name="(CANTX)A7" x="16.51" y="21.59" drill="0.8" shape="long"/>
+<pad name="(CANRX)A8" x="16.51" y="24.13" drill="0.8" shape="long"/>
+<pad name="D12" x="1.27" y="1.27" drill="0.8" shape="long"/>
+<pad name="D11" x="1.27" y="3.81" drill="0.8" shape="long"/>
+<pad name="D5" x="1.27" y="19.05" drill="0.8" shape="long"/>
+<pad name="D4" x="1.27" y="21.59" drill="0.8" shape="long"/>
+<pad name="D3" x="1.27" y="24.13" drill="0.8" shape="long"/>
+<pad name="D2" x="1.27" y="26.67" drill="0.8" shape="long"/>
+<pad name="GND" x="1.27" y="34.29" drill="0.8" shape="long"/>
+<pad name="VIN" x="16.51" y="34.29" drill="0.8" shape="long"/>
+<pad name="3.3V" x="16.51" y="29.21" drill="0.8" shape="long"/>
+<pad name="A9" x="16.51" y="26.67" drill="0.8" shape="long"/>
+<pad name="D0(RX1)" x="1.27" y="31.75" drill="0.8" shape="long" rot="R180"/>
+<pad name="D1(TX1)" x="1.27" y="29.21" drill="0.8" shape="long" rot="R180"/>
+<pad name="D10" x="1.27" y="6.35" drill="0.8" shape="long"/>
+<pad name="D6" x="1.27" y="16.51" drill="0.8" shape="long" rot="R180"/>
+<pad name="D7(RX2)" x="1.27" y="13.97" drill="0.8" shape="long" rot="R180"/>
+<pad name="D8(TX2)" x="1.27" y="11.43" drill="0.8" shape="long" rot="R180"/>
+<pad name="D9" x="1.27" y="8.89" drill="0.8" shape="long" rot="R180"/>
+<wire x1="17.78" y1="35.56" x2="17.78" y2="0" width="0.127" layer="21"/>
+<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="36.322" x2="12.7" y2="36.322" width="0.127" layer="21"/>
+<wire x1="12.7" y1="36.322" x2="12.7" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="35.56" x2="5.08" y2="36.322" width="0.127" layer="21"/>
+<wire x1="0" y1="35.56" x2="5.08" y2="35.56" width="0.127" layer="21"/>
+<wire x1="12.7" y1="35.56" x2="17.78" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="35.56" x2="5.08" y2="30.48" width="0.127" layer="21"/>
+<wire x1="5.08" y1="30.48" x2="12.7" y2="30.48" width="0.127" layer="21"/>
+<wire x1="12.7" y1="30.48" x2="12.7" y2="35.56" width="0.127" layer="21"/>
+<text x="8.89" y="33.3375" size="2.54" layer="21" align="center">4.0</text>
 </package>
 <package name="MSOP-8_MS-L">
 <smd name="1" x="-2.159" y="0.975" dx="1.0922" dy="0.381" layer="1"/>
@@ -10632,269 +10263,423 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
 <text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
 </package>
-<package name="21-0041B_8">
-<smd name="1" x="-2.4638" y="1.905" dx="1.9812" dy="0.5334" layer="1"/>
-<smd name="2" x="-2.4638" y="0.635" dx="1.9812" dy="0.5334" layer="1"/>
-<smd name="3" x="-2.4638" y="-0.635" dx="1.9812" dy="0.5334" layer="1"/>
-<smd name="4" x="-2.4638" y="-1.905" dx="1.9812" dy="0.5334" layer="1"/>
-<smd name="5" x="2.4638" y="-1.905" dx="1.9812" dy="0.5334" layer="1"/>
-<smd name="6" x="2.4638" y="-0.635" dx="1.9812" dy="0.5334" layer="1"/>
-<smd name="7" x="2.4638" y="0.635" dx="1.9812" dy="0.5334" layer="1"/>
-<smd name="8" x="2.4638" y="1.905" dx="1.9812" dy="0.5334" layer="1"/>
-<wire x1="-1.9812" y1="1.6764" x2="-2.0066" y2="2.1336" width="0.1524" layer="51"/>
-<wire x1="-2.0066" y1="2.1336" x2="-3.0988" y2="2.1336" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="2.1336" x2="-3.0988" y2="1.651" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="1.651" x2="-1.9812" y2="1.6764" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="0.4064" x2="-2.0066" y2="0.8636" width="0.1524" layer="51"/>
-<wire x1="-2.0066" y1="0.8636" x2="-3.0988" y2="0.8636" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="0.8636" x2="-3.0988" y2="0.381" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="0.381" x2="-1.9812" y2="0.4064" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-0.8636" x2="-1.9812" y2="-0.4064" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-0.4064" x2="-3.0988" y2="-0.4064" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-0.4064" x2="-3.0988" y2="-0.889" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-0.889" x2="-1.9812" y2="-0.8636" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-2.1336" x2="-1.9812" y2="-1.6764" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-1.6764" x2="-3.0988" y2="-1.6764" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-1.6764" x2="-3.0988" y2="-2.159" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-2.159" x2="-1.9812" y2="-2.1336" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-1.6764" x2="2.0066" y2="-2.1336" width="0.1524" layer="51"/>
-<wire x1="2.0066" y1="-2.1336" x2="3.0988" y2="-2.1336" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-2.1336" x2="3.0988" y2="-1.651" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-1.651" x2="1.9812" y2="-1.6764" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-0.4064" x2="1.9812" y2="-0.8636" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-0.8636" x2="3.0988" y2="-0.8636" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-0.8636" x2="3.0988" y2="-0.381" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-0.381" x2="1.9812" y2="-0.4064" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="0.8636" x2="1.9812" y2="0.4064" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="0.4064" x2="3.0988" y2="0.4064" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="0.4064" x2="3.0988" y2="0.889" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="0.889" x2="1.9812" y2="0.8636" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="2.1336" x2="1.9812" y2="1.6764" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="1.6764" x2="3.0988" y2="1.6764" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="1.6764" x2="3.0988" y2="2.159" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="2.159" x2="1.9812" y2="2.1336" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-2.4892" x2="1.9812" y2="-2.4892" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-2.4892" x2="1.9812" y2="2.4892" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="2.4892" x2="-0.3048" y2="2.4892" width="0.1524" layer="51"/>
-<wire x1="-0.3048" y1="2.4892" x2="-1.9812" y2="2.4892" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="2.4892" x2="-1.9812" y2="-2.4892" width="0.1524" layer="51"/>
-<wire x1="0.3048" y1="2.5146" x2="-0.3048" y2="2.4892" width="0.1524" layer="51" curve="-180"/>
-<text x="-2.1844" y="1.1684" size="1.27" layer="51" ratio="6" rot="SR0">*</text>
-<wire x1="-3.7084" y1="-2.4384" x2="-3.7084" y2="2.4384" width="0.1524" layer="39"/>
-<wire x1="-3.7084" y1="2.4384" x2="-2.2352" y2="2.4384" width="0.1524" layer="39"/>
-<wire x1="-2.2352" y1="2.4384" x2="-2.2352" y2="2.7432" width="0.1524" layer="39"/>
-<wire x1="-2.2352" y1="2.7432" x2="2.2352" y2="2.7432" width="0.1524" layer="39"/>
-<wire x1="2.2352" y1="2.7432" x2="2.2352" y2="2.4384" width="0.1524" layer="39"/>
-<wire x1="3.7084" y1="2.4384" x2="2.2352" y2="2.4384" width="0.1524" layer="39"/>
-<wire x1="3.7084" y1="2.4384" x2="3.7084" y2="-2.4384" width="0.1524" layer="39"/>
-<wire x1="3.7084" y1="-2.4384" x2="2.2352" y2="-2.4384" width="0.1524" layer="39"/>
-<wire x1="2.2352" y1="-2.4384" x2="2.2352" y2="-2.7432" width="0.1524" layer="39"/>
-<wire x1="2.2352" y1="-2.7432" x2="-2.2352" y2="-2.7432" width="0.1524" layer="39"/>
-<wire x1="-2.2352" y1="-2.7432" x2="-2.2352" y2="-2.4384" width="0.1524" layer="39"/>
-<wire x1="-3.7084" y1="-2.4384" x2="-2.2352" y2="-2.4384" width="0.1524" layer="39"/>
-<polygon width="0.1524" layer="39">
-<vertex x="-3.7084" y="-2.4257"/>
-<vertex x="-3.7084" y="2.4257"/>
-<vertex x="-2.2479" y="2.4257"/>
-<vertex x="-2.2479" y="2.7559"/>
-<vertex x="2.2479" y="2.7559"/>
-<vertex x="2.2479" y="2.4257"/>
-<vertex x="3.7084" y="2.4257"/>
-<vertex x="3.7084" y="-2.4257"/>
-<vertex x="2.2479" y="-2.4257"/>
-<vertex x="2.2479" y="-2.7559"/>
-<vertex x="-2.2479" y="-2.7559"/>
-<vertex x="-2.2479" y="-2.4257"/>
-</polygon>
-<wire x1="-2.1336" y1="-2.6416" x2="2.1336" y2="-2.6416" width="0.1524" layer="21"/>
-<wire x1="2.1336" y1="2.6416" x2="-2.1336" y2="2.6416" width="0.1524" layer="21"/>
-<text x="-3.302" y="2.3114" size="1.27" layer="21" ratio="6" rot="SR0">*</text>
-<wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
-<wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
-<text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+<package name="AUTOSPORT_12-35">
+<pad name="P$1" x="1.143" y="5.0038" drill="1"/>
+<pad name="P$2" x="3.2004" y="4.0132" drill="1"/>
+<pad name="P$3" x="4.6228" y="2.2352" drill="1"/>
+<pad name="P$4" x="5.1562" y="0" drill="1"/>
+<pad name="P$5" x="4.6228" y="-2.2352" drill="1"/>
+<pad name="P$6" x="3.2004" y="-4.0132" drill="1"/>
+<pad name="P$7" x="1.143" y="-5.0038" drill="1"/>
+<pad name="P$8" x="-1.143" y="-5.0038" drill="1"/>
+<pad name="P$9" x="-3.2004" y="-4.0132" drill="1"/>
+<pad name="P$10" x="-4.6228" y="-2.2352" drill="1"/>
+<pad name="P$11" x="-5.1562" y="0" drill="1"/>
+<pad name="P$12" x="-3.2004" y="4.0132" drill="1"/>
+<pad name="P$13" x="-1.143" y="5.0038" drill="1"/>
+<pad name="P$14" x="1.143" y="2.7178" drill="1"/>
+<pad name="P$15" x="2.9718" y="0.6604" drill="1"/>
+<pad name="P$16" x="2.3622" y="-1.905" drill="1"/>
+<pad name="P$17" x="-2.3622" y="-1.905" drill="1"/>
+<pad name="P$18" x="-2.9718" y="0.6604" drill="1"/>
+<pad name="P$19" x="-1.143" y="2.7178" drill="1"/>
+<pad name="P$20" x="0" y="-0.762" drill="1"/>
+<pad name="P$21" x="0" y="-3.048" drill="1"/>
+<pad name="P$22" x="-4.6228" y="2.2352" drill="1"/>
+<circle x="0" y="0" radius="8.725" width="0.127" layer="21"/>
+<hole x="-10.2884" y="-10.2884" drill="3.3"/>
+<hole x="10.2884" y="10.2884" drill="3.3"/>
+<circle x="-10.2884" y="-10.2884" radius="3" width="0.127" layer="40"/>
+<circle x="10.2884" y="10.2884" radius="3" width="0.127" layer="40"/>
+<circle x="0" y="0" radius="13" width="0.127" layer="21"/>
 </package>
-<package name="21-0041B_8-M">
-<smd name="1" x="-2.5146" y="1.905" dx="2.286" dy="0.5842" layer="1"/>
-<smd name="2" x="-2.5146" y="0.635" dx="2.286" dy="0.5842" layer="1"/>
-<smd name="3" x="-2.5146" y="-0.635" dx="2.286" dy="0.5842" layer="1"/>
-<smd name="4" x="-2.5146" y="-1.905" dx="2.286" dy="0.5842" layer="1"/>
-<smd name="5" x="2.5146" y="-1.905" dx="2.286" dy="0.5842" layer="1"/>
-<smd name="6" x="2.5146" y="-0.635" dx="2.286" dy="0.5842" layer="1"/>
-<smd name="7" x="2.5146" y="0.635" dx="2.286" dy="0.5842" layer="1"/>
-<smd name="8" x="2.5146" y="1.905" dx="2.286" dy="0.5842" layer="1"/>
-<wire x1="-1.9812" y1="1.6764" x2="-2.0066" y2="2.1336" width="0.1524" layer="51"/>
-<wire x1="-2.0066" y1="2.1336" x2="-3.0988" y2="2.1336" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="2.1336" x2="-3.0988" y2="1.651" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="1.651" x2="-1.9812" y2="1.6764" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="0.4064" x2="-2.0066" y2="0.8636" width="0.1524" layer="51"/>
-<wire x1="-2.0066" y1="0.8636" x2="-3.0988" y2="0.8636" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="0.8636" x2="-3.0988" y2="0.381" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="0.381" x2="-1.9812" y2="0.4064" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-0.8636" x2="-1.9812" y2="-0.4064" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-0.4064" x2="-3.0988" y2="-0.4064" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-0.4064" x2="-3.0988" y2="-0.889" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-0.889" x2="-1.9812" y2="-0.8636" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-2.1336" x2="-1.9812" y2="-1.6764" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-1.6764" x2="-3.0988" y2="-1.6764" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-1.6764" x2="-3.0988" y2="-2.159" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-2.159" x2="-1.9812" y2="-2.1336" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-1.6764" x2="2.0066" y2="-2.1336" width="0.1524" layer="51"/>
-<wire x1="2.0066" y1="-2.1336" x2="3.0988" y2="-2.1336" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-2.1336" x2="3.0988" y2="-1.651" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-1.651" x2="1.9812" y2="-1.6764" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-0.4064" x2="1.9812" y2="-0.8636" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-0.8636" x2="3.0988" y2="-0.8636" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-0.8636" x2="3.0988" y2="-0.381" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-0.381" x2="1.9812" y2="-0.4064" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="0.8636" x2="1.9812" y2="0.4064" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="0.4064" x2="3.0988" y2="0.4064" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="0.4064" x2="3.0988" y2="0.889" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="0.889" x2="1.9812" y2="0.8636" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="2.1336" x2="1.9812" y2="1.6764" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="1.6764" x2="3.0988" y2="1.6764" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="1.6764" x2="3.0988" y2="2.159" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="2.159" x2="1.9812" y2="2.1336" width="0.1524" layer="51"/>
+<package name="TEENSY_3.6_EXT_RTC">
+<pad name="AGND" x="16.51" y="57.15" drill="0.8" shape="long"/>
+<pad name="D13" x="16.51" y="26.67" drill="0.8" shape="long"/>
+<pad name="A0" x="16.51" y="29.21" drill="0.8" shape="long"/>
+<pad name="A1" x="16.51" y="31.75" drill="0.8" shape="long"/>
+<pad name="A2" x="16.51" y="34.29" drill="0.8" shape="long"/>
+<pad name="A3" x="16.51" y="36.83" drill="0.8" shape="long"/>
+<pad name="A4" x="16.51" y="39.37" drill="0.8" shape="long"/>
+<pad name="A5" x="16.51" y="41.91" drill="0.8" shape="long"/>
+<pad name="A6" x="16.51" y="44.45" drill="0.8" shape="long"/>
+<pad name="A7" x="16.51" y="46.99" drill="0.8" shape="long"/>
+<pad name="A8" x="16.51" y="49.53" drill="0.8" shape="long"/>
+<pad name="D12" x="1.27" y="26.67" drill="0.8" shape="long"/>
+<pad name="D11" x="1.27" y="29.21" drill="0.8" shape="long"/>
+<pad name="D5" x="1.27" y="44.45" drill="0.8" shape="long"/>
+<pad name="D4(CANRX)" x="1.27" y="46.99" drill="0.8" shape="long"/>
+<pad name="D3(CANTX)" x="1.27" y="49.53" drill="0.8" shape="long"/>
+<pad name="D2" x="1.27" y="52.07" drill="0.8" shape="long"/>
+<pad name="GND" x="1.27" y="59.69" drill="0.8" shape="long"/>
+<pad name="VIN" x="16.51" y="59.69" drill="0.8" shape="long"/>
+<pad name="3.3V3" x="16.51" y="54.61" drill="0.8" shape="long"/>
+<pad name="A9" x="16.51" y="52.07" drill="0.8" shape="long"/>
+<pad name="D0(RX1)" x="1.27" y="57.15" drill="0.8" shape="long" rot="R180"/>
+<pad name="D1(TX1)" x="1.27" y="54.61" drill="0.8" shape="long" rot="R180"/>
+<pad name="D10(TX2)" x="1.27" y="31.75" drill="0.8" shape="long"/>
+<pad name="D6" x="1.27" y="41.91" drill="0.8" shape="long" rot="R180"/>
+<pad name="D7(RX3)" x="1.27" y="39.37" drill="0.8" shape="long" rot="R180"/>
+<pad name="D8(TX3)" x="1.27" y="36.83" drill="0.8" shape="long" rot="R180"/>
+<pad name="D9(RX2)" x="1.27" y="34.29" drill="0.8" shape="long" rot="R180"/>
+<wire x1="17.78" y1="60.96" x2="17.78" y2="0" width="0.127" layer="21"/>
+<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="61.722" x2="12.7" y2="61.722" width="0.127" layer="21"/>
+<wire x1="12.7" y1="61.722" x2="12.7" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="60.96" x2="5.08" y2="61.722" width="0.127" layer="21"/>
+<wire x1="0" y1="60.96" x2="5.08" y2="60.96" width="0.127" layer="21"/>
+<wire x1="12.7" y1="60.96" x2="17.78" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="60.96" x2="5.08" y2="55.88" width="0.127" layer="21"/>
+<wire x1="5.08" y1="55.88" x2="12.7" y2="55.88" width="0.127" layer="21"/>
+<wire x1="12.7" y1="55.88" x2="12.7" y2="60.96" width="0.127" layer="21"/>
+<pad name="3.3V" x="1.27" y="24.13" drill="0.8" shape="long"/>
+<pad name="D24" x="1.27" y="21.59" drill="0.8" shape="long"/>
+<pad name="D25" x="1.27" y="19.05" drill="0.8" shape="long"/>
+<pad name="D26" x="1.27" y="16.51" drill="0.8" shape="long"/>
+<pad name="D27" x="1.27" y="13.97" drill="0.8" shape="long"/>
+<pad name="D28" x="1.27" y="11.43" drill="0.8" shape="long"/>
+<pad name="D29" x="1.27" y="8.89" drill="0.8" shape="long"/>
+<pad name="D30" x="1.27" y="6.35" drill="0.8" shape="long"/>
+<pad name="A12" x="1.27" y="3.81" drill="0.8" shape="long"/>
+<pad name="A13" x="1.27" y="1.27" drill="0.8" shape="long"/>
+<pad name="GND3" x="16.51" y="24.13" drill="0.8" shape="long"/>
+<pad name="A22" x="16.51" y="21.59" drill="0.8" shape="long"/>
+<pad name="A21" x="16.51" y="19.05" drill="0.8" shape="long"/>
+<pad name="A20" x="16.51" y="16.51" drill="0.8" shape="long"/>
+<pad name="A19" x="16.51" y="13.97" drill="0.8" shape="long"/>
+<pad name="A18" x="16.51" y="11.43" drill="0.8" shape="long"/>
+<pad name="A17" x="16.51" y="8.89" drill="0.8" shape="long"/>
+<pad name="A16" x="16.51" y="6.35" drill="0.8" shape="long"/>
+<pad name="A15" x="16.51" y="3.81" drill="0.8" shape="long"/>
+<pad name="A14" x="16.51" y="1.27" drill="0.8" shape="long"/>
+<pad name="VBAT" x="3.81" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<pad name="3.3V2" x="6.35" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<pad name="GND2" x="8.89" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<pad name="PRGM" x="11.43" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<pad name="RST" x="13.97" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<text x="8.89" y="58.7375" size="2.54" layer="21" align="center">3.6</text>
+</package>
+<package name="TEENSY_LC_SIMPLE">
+<pad name="AGND" x="16.51" y="31.75" drill="0.8" shape="long"/>
+<pad name="D13" x="16.51" y="1.27" drill="0.8" shape="long"/>
+<pad name="A0" x="16.51" y="3.81" drill="0.8" shape="long"/>
+<pad name="A1" x="16.51" y="6.35" drill="0.8" shape="long"/>
+<pad name="A2" x="16.51" y="8.89" drill="0.8" shape="long"/>
+<pad name="A3" x="16.51" y="11.43" drill="0.8" shape="long"/>
+<pad name="A4" x="16.51" y="13.97" drill="0.8" shape="long"/>
+<pad name="A5" x="16.51" y="16.51" drill="0.8" shape="long"/>
+<pad name="A6" x="16.51" y="19.05" drill="0.8" shape="long"/>
+<pad name="A7" x="16.51" y="21.59" drill="0.8" shape="long"/>
+<pad name="A8" x="16.51" y="24.13" drill="0.8" shape="long"/>
+<pad name="D12" x="1.27" y="1.27" drill="0.8" shape="long"/>
+<pad name="D11" x="1.27" y="3.81" drill="0.8" shape="long"/>
+<pad name="D5" x="1.27" y="19.05" drill="0.8" shape="long"/>
+<pad name="D4" x="1.27" y="21.59" drill="0.8" shape="long"/>
+<pad name="D3" x="1.27" y="24.13" drill="0.8" shape="long"/>
+<pad name="D2" x="1.27" y="26.67" drill="0.8" shape="long"/>
+<pad name="GND" x="1.27" y="34.29" drill="0.8" shape="long"/>
+<pad name="VIN" x="16.51" y="34.29" drill="0.8" shape="long"/>
+<pad name="3.3V" x="16.51" y="29.21" drill="0.8" shape="long"/>
+<pad name="A9" x="16.51" y="26.67" drill="0.8" shape="long"/>
+<pad name="D0(RX1)" x="1.27" y="31.75" drill="0.8" shape="long" rot="R180"/>
+<pad name="D1(TX1)" x="1.27" y="29.21" drill="0.8" shape="long" rot="R180"/>
+<pad name="D10(TX2)" x="1.27" y="6.35" drill="0.8" shape="long"/>
+<pad name="D6" x="1.27" y="16.51" drill="0.8" shape="long" rot="R180"/>
+<pad name="D7(RX3)" x="1.27" y="13.97" drill="0.8" shape="long" rot="R180"/>
+<pad name="D8(TX3)" x="1.27" y="11.43" drill="0.8" shape="long" rot="R180"/>
+<pad name="D9(RX2)" x="1.27" y="8.89" drill="0.8" shape="long" rot="R180"/>
+<wire x1="17.78" y1="35.56" x2="17.78" y2="0" width="0.127" layer="21"/>
+<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="36.322" x2="12.7" y2="36.322" width="0.127" layer="21"/>
+<wire x1="12.7" y1="36.322" x2="12.7" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="35.56" x2="5.08" y2="36.322" width="0.127" layer="21"/>
+<wire x1="0" y1="35.56" x2="5.08" y2="35.56" width="0.127" layer="21"/>
+<wire x1="12.7" y1="35.56" x2="17.78" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="35.56" x2="5.08" y2="30.48" width="0.127" layer="21"/>
+<wire x1="5.08" y1="30.48" x2="12.7" y2="30.48" width="0.127" layer="21"/>
+<wire x1="12.7" y1="30.48" x2="12.7" y2="35.56" width="0.127" layer="21"/>
+<text x="9.2075" y="33.3375" size="2.54" layer="21" align="center">LC</text>
+</package>
+<package name="SSOP-16_GN-M">
+<smd name="1" x="-2.5146" y="2.2225" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="2" x="-2.5146" y="1.5875" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="3" x="-2.5146" y="0.9525" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="4" x="-2.5146" y="0.3175" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="5" x="-2.5146" y="-0.3175" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="6" x="-2.5146" y="-0.9525" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="7" x="-2.5146" y="-1.5875" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="8" x="-2.5146" y="-2.2225" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="9" x="2.5146" y="-2.2225" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="10" x="2.5146" y="-1.5875" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="11" x="2.5146" y="-0.9525" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="12" x="2.5146" y="-0.3175" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="13" x="2.5146" y="0.3175" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="14" x="2.5146" y="0.9525" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="15" x="2.5146" y="1.5875" dx="2.286" dy="0.4064" layer="1"/>
+<smd name="16" x="2.5146" y="2.2225" dx="2.286" dy="0.4064" layer="1"/>
+<wire x1="-1.9812" y1="2.0828" x2="-2.0066" y2="2.3876" width="0.1524" layer="51"/>
+<wire x1="-2.0066" y1="2.3876" x2="-3.0988" y2="2.3622" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="2.3622" x2="-3.0988" y2="2.0574" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="2.0574" x2="-1.9812" y2="2.0828" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="1.4224" x2="-2.0066" y2="1.7272" width="0.1524" layer="51"/>
+<wire x1="-2.0066" y1="1.7272" x2="-3.0988" y2="1.7272" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="1.7272" x2="-3.0988" y2="1.4224" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="1.4224" x2="-1.9812" y2="1.4224" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="0.8128" x2="-1.9812" y2="1.1176" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="1.1176" x2="-3.0988" y2="1.0922" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="1.0922" x2="-3.0988" y2="0.7874" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="0.7874" x2="-1.9812" y2="0.8128" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="0.1524" x2="-1.9812" y2="0.4572" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="0.4572" x2="-3.0988" y2="0.4572" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="0.4572" x2="-3.0988" y2="0.1524" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="0.1524" x2="-1.9812" y2="0.1524" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-0.4572" x2="-1.9812" y2="-0.1524" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-0.1524" x2="-3.0988" y2="-0.1778" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-0.1778" x2="-3.0988" y2="-0.4826" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-0.4826" x2="-1.9812" y2="-0.4572" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-1.1176" x2="-1.9812" y2="-0.8128" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-0.8128" x2="-3.0988" y2="-0.8128" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-0.8128" x2="-3.0988" y2="-1.1176" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-1.1176" x2="-1.9812" y2="-1.1176" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-1.7272" x2="-1.9812" y2="-1.4224" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-1.4224" x2="-3.0988" y2="-1.4478" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-1.4478" x2="-3.0988" y2="-1.7526" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-1.7526" x2="-1.9812" y2="-1.7272" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-2.3876" x2="-1.9812" y2="-2.0828" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-2.0828" x2="-3.0988" y2="-2.0828" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-2.0828" x2="-3.0988" y2="-2.3876" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-2.3876" x2="-1.9812" y2="-2.3876" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-2.0828" x2="2.0066" y2="-2.3876" width="0.1524" layer="51"/>
+<wire x1="2.0066" y1="-2.3876" x2="3.0988" y2="-2.3622" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-2.3622" x2="3.0988" y2="-2.0574" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-2.0574" x2="1.9812" y2="-2.0828" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-1.4224" x2="1.9812" y2="-1.7272" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-1.7272" x2="3.0988" y2="-1.7272" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-1.7272" x2="3.0988" y2="-1.4224" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-1.4224" x2="1.9812" y2="-1.4224" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-0.8128" x2="1.9812" y2="-1.1176" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-1.1176" x2="3.0988" y2="-1.0922" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-1.0922" x2="3.0988" y2="-0.7874" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-0.7874" x2="1.9812" y2="-0.8128" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-0.1524" x2="1.9812" y2="-0.4572" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-0.4572" x2="3.0988" y2="-0.4572" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-0.4572" x2="3.0988" y2="-0.1524" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-0.1524" x2="1.9812" y2="-0.1524" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="0.4572" x2="1.9812" y2="0.1524" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="0.1524" x2="3.0988" y2="0.1778" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="0.1778" x2="3.0988" y2="0.4826" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="0.4826" x2="1.9812" y2="0.4572" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="1.1176" x2="1.9812" y2="0.8128" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="0.8128" x2="3.0988" y2="0.8128" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="0.8128" x2="3.0988" y2="1.1176" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="1.1176" x2="1.9812" y2="1.1176" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="1.7272" x2="1.9812" y2="1.4224" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="1.4224" x2="3.0988" y2="1.4478" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="1.4478" x2="3.0988" y2="1.7526" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="1.7526" x2="1.9812" y2="1.7272" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="2.3876" x2="1.9812" y2="2.0828" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="2.0828" x2="3.0988" y2="2.0828" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="2.0828" x2="3.0988" y2="2.3876" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="2.3876" x2="1.9812" y2="2.3876" width="0.1524" layer="51"/>
 <wire x1="-1.9812" y1="-2.4892" x2="1.9812" y2="-2.4892" width="0.1524" layer="51"/>
 <wire x1="1.9812" y1="-2.4892" x2="1.9812" y2="2.4892" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="2.4892" x2="-0.3048" y2="2.4892" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="2.4892" x2="0.3048" y2="2.4892" width="0.1524" layer="51"/>
+<wire x1="0.3048" y1="2.4892" x2="-0.3048" y2="2.4892" width="0.1524" layer="51"/>
 <wire x1="-0.3048" y1="2.4892" x2="-1.9812" y2="2.4892" width="0.1524" layer="51"/>
 <wire x1="-1.9812" y1="2.4892" x2="-1.9812" y2="-2.4892" width="0.1524" layer="51"/>
-<wire x1="0.3048" y1="2.5146" x2="-0.3048" y2="2.4892" width="0.1524" layer="51" curve="-180"/>
-<text x="-2.1844" y="1.1684" size="1.27" layer="51" ratio="6" rot="SR0">*</text>
-<wire x1="-4.1656" y1="-2.6924" x2="-4.1656" y2="2.6924" width="0.1524" layer="39"/>
-<wire x1="-4.1656" y1="2.6924" x2="-2.4892" y2="2.6924" width="0.1524" layer="39"/>
-<wire x1="-2.4892" y1="2.6924" x2="-2.4892" y2="2.9972" width="0.1524" layer="39"/>
+<wire x1="0.3048" y1="2.4892" x2="-0.3048" y2="2.4892" width="0.1524" layer="51" curve="-180"/>
+<text x="-2.1844" y="1.143" size="1.27" layer="51" ratio="6" rot="SR0">*</text>
+<wire x1="-1.0922" y1="-2.6162" x2="1.0922" y2="-2.6162" width="0.1524" layer="21"/>
+<wire x1="1.0922" y1="2.6162" x2="-1.0922" y2="2.6162" width="0.1524" layer="21"/>
+<polygon width="0.0254" layer="21">
+<vertex x="4.1656" y="-1.397"/>
+<vertex x="4.1656" y="-1.778"/>
+<vertex x="3.9116" y="-1.778"/>
+<vertex x="3.9116" y="-1.397"/>
+</polygon>
+<text x="-3.3528" y="2.4892" size="1.27" layer="21" ratio="6" rot="SR0">*</text>
+<wire x1="-4.1656" y1="-2.9464" x2="-4.1656" y2="2.9464" width="0.1524" layer="39"/>
+<wire x1="-4.1656" y1="2.9464" x2="-2.4892" y2="2.9464" width="0.1524" layer="39"/>
+<wire x1="-2.4892" y1="2.9464" x2="-2.4892" y2="2.9972" width="0.1524" layer="39"/>
 <wire x1="-2.4892" y1="2.9972" x2="2.4892" y2="2.9972" width="0.1524" layer="39"/>
-<wire x1="2.4892" y1="2.9972" x2="2.4892" y2="2.6924" width="0.1524" layer="39"/>
-<wire x1="4.1656" y1="2.6924" x2="2.4892" y2="2.6924" width="0.1524" layer="39"/>
-<wire x1="4.1656" y1="2.6924" x2="4.1656" y2="-2.6924" width="0.1524" layer="39"/>
-<wire x1="4.1656" y1="-2.6924" x2="2.4892" y2="-2.6924" width="0.1524" layer="39"/>
-<wire x1="2.4892" y1="-2.6924" x2="2.4892" y2="-2.9972" width="0.1524" layer="39"/>
+<wire x1="2.4892" y1="2.9972" x2="2.4892" y2="2.9464" width="0.1524" layer="39"/>
+<wire x1="4.1656" y1="2.9464" x2="2.4892" y2="2.9464" width="0.1524" layer="39"/>
+<wire x1="4.1656" y1="2.9464" x2="4.1656" y2="-2.9464" width="0.1524" layer="39"/>
+<wire x1="4.1656" y1="-2.9464" x2="2.4892" y2="-2.9464" width="0.1524" layer="39"/>
+<wire x1="2.4892" y1="-2.9464" x2="2.4892" y2="-2.9972" width="0.1524" layer="39"/>
 <wire x1="2.4892" y1="-2.9972" x2="-2.4892" y2="-2.9972" width="0.1524" layer="39"/>
-<wire x1="-2.4892" y1="-2.9972" x2="-2.4892" y2="-2.6924" width="0.1524" layer="39"/>
-<wire x1="-4.1656" y1="-2.6924" x2="-2.4892" y2="-2.6924" width="0.1524" layer="39"/>
+<wire x1="-2.4892" y1="-2.9972" x2="-2.4892" y2="-2.9464" width="0.1524" layer="39"/>
+<wire x1="-4.1656" y1="-2.9464" x2="-2.4892" y2="-2.9464" width="0.1524" layer="39"/>
 <polygon width="0.1524" layer="39">
-<vertex x="-4.1656" y="-2.7051"/>
-<vertex x="-4.1656" y="2.7051"/>
-<vertex x="-2.5019" y="2.7051"/>
-<vertex x="-2.5019" y="3.0099"/>
-<vertex x="2.5019" y="3.0099"/>
-<vertex x="2.5019" y="2.7051"/>
-<vertex x="4.1656" y="2.7051"/>
-<vertex x="4.1656" y="-2.7051"/>
-<vertex x="2.5019" y="-2.7051"/>
-<vertex x="2.5019" y="-3.0099"/>
-<vertex x="-2.5019" y="-3.0099"/>
-<vertex x="-2.5019" y="-2.7051"/>
+<vertex x="-4.1656" y="-2.9337"/>
+<vertex x="-4.1656" y="2.9337"/>
+<vertex x="-2.5019" y="2.9337"/>
+<vertex x="-2.5019" y="2.9972"/>
+<vertex x="2.5019" y="2.9972"/>
+<vertex x="2.5019" y="2.9337"/>
+<vertex x="4.1656" y="2.9337"/>
+<vertex x="4.1656" y="-2.9337"/>
+<vertex x="2.5019" y="-2.9337"/>
+<vertex x="2.5019" y="-2.9972"/>
+<vertex x="-2.5019" y="-2.9972"/>
+<vertex x="-2.5019" y="-2.9337"/>
 </polygon>
-<wire x1="-2.1336" y1="-2.6416" x2="2.1336" y2="-2.6416" width="0.1524" layer="21"/>
-<wire x1="2.1336" y1="2.6416" x2="-2.1336" y2="2.6416" width="0.1524" layer="21"/>
-<text x="-3.3528" y="2.3622" size="1.27" layer="21" ratio="6" rot="SR0">*</text>
 <wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
 <wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
 <text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
 </package>
-<package name="21-0041B_8-L">
-<smd name="1" x="-2.413" y="1.905" dx="1.6764" dy="0.4826" layer="1"/>
-<smd name="2" x="-2.413" y="0.635" dx="1.6764" dy="0.4826" layer="1"/>
-<smd name="3" x="-2.413" y="-0.635" dx="1.6764" dy="0.4826" layer="1"/>
-<smd name="4" x="-2.413" y="-1.905" dx="1.6764" dy="0.4826" layer="1"/>
-<smd name="5" x="2.413" y="-1.905" dx="1.6764" dy="0.4826" layer="1"/>
-<smd name="6" x="2.413" y="-0.635" dx="1.6764" dy="0.4826" layer="1"/>
-<smd name="7" x="2.413" y="0.635" dx="1.6764" dy="0.4826" layer="1"/>
-<smd name="8" x="2.413" y="1.905" dx="1.6764" dy="0.4826" layer="1"/>
-<wire x1="-1.9812" y1="1.6764" x2="-2.0066" y2="2.1336" width="0.1524" layer="51"/>
-<wire x1="-2.0066" y1="2.1336" x2="-3.0988" y2="2.1336" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="2.1336" x2="-3.0988" y2="1.651" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="1.651" x2="-1.9812" y2="1.6764" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="0.4064" x2="-2.0066" y2="0.8636" width="0.1524" layer="51"/>
-<wire x1="-2.0066" y1="0.8636" x2="-3.0988" y2="0.8636" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="0.8636" x2="-3.0988" y2="0.381" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="0.381" x2="-1.9812" y2="0.4064" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-0.8636" x2="-1.9812" y2="-0.4064" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-0.4064" x2="-3.0988" y2="-0.4064" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-0.4064" x2="-3.0988" y2="-0.889" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-0.889" x2="-1.9812" y2="-0.8636" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-2.1336" x2="-1.9812" y2="-1.6764" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-1.6764" x2="-3.0988" y2="-1.6764" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-1.6764" x2="-3.0988" y2="-2.159" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-2.159" x2="-1.9812" y2="-2.1336" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-1.6764" x2="2.0066" y2="-2.1336" width="0.1524" layer="51"/>
-<wire x1="2.0066" y1="-2.1336" x2="3.0988" y2="-2.1336" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-2.1336" x2="3.0988" y2="-1.651" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-1.651" x2="1.9812" y2="-1.6764" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-0.4064" x2="1.9812" y2="-0.8636" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-0.8636" x2="3.0988" y2="-0.8636" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-0.8636" x2="3.0988" y2="-0.381" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-0.381" x2="1.9812" y2="-0.4064" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="0.8636" x2="1.9812" y2="0.4064" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="0.4064" x2="3.0988" y2="0.4064" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="0.4064" x2="3.0988" y2="0.889" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="0.889" x2="1.9812" y2="0.8636" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="2.1336" x2="1.9812" y2="1.6764" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="1.6764" x2="3.0988" y2="1.6764" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="1.6764" x2="3.0988" y2="2.159" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="2.159" x2="1.9812" y2="2.1336" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-2.4892" x2="1.9812" y2="-2.4892" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-2.4892" x2="1.9812" y2="2.4892" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="2.4892" x2="-0.3048" y2="2.4892" width="0.1524" layer="51"/>
-<wire x1="-0.3048" y1="2.4892" x2="-1.9812" y2="2.4892" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="2.4892" x2="-1.9812" y2="-2.4892" width="0.1524" layer="51"/>
-<wire x1="0.3048" y1="2.5146" x2="-0.3048" y2="2.4892" width="0.1524" layer="51" curve="-180"/>
-<text x="-2.1844" y="1.1684" size="1.27" layer="51" ratio="6" rot="SR0">*</text>
-<wire x1="-3.3528" y1="-2.2352" x2="-3.3528" y2="2.2352" width="0.1524" layer="39"/>
-<wire x1="-3.3528" y1="2.2352" x2="-2.0828" y2="2.2352" width="0.1524" layer="39"/>
-<wire x1="-2.0828" y1="2.2352" x2="-2.0828" y2="2.5908" width="0.1524" layer="39"/>
-<wire x1="-2.0828" y1="2.5908" x2="2.0828" y2="2.5908" width="0.1524" layer="39"/>
-<wire x1="2.0828" y1="2.5908" x2="2.0828" y2="2.2352" width="0.1524" layer="39"/>
-<wire x1="3.3528" y1="2.2352" x2="2.0828" y2="2.2352" width="0.1524" layer="39"/>
-<wire x1="3.3528" y1="2.2352" x2="3.3528" y2="-2.2352" width="0.1524" layer="39"/>
-<wire x1="3.3528" y1="-2.2352" x2="2.0828" y2="-2.2352" width="0.1524" layer="39"/>
-<wire x1="2.0828" y1="-2.2352" x2="2.0828" y2="-2.5908" width="0.1524" layer="39"/>
-<wire x1="2.0828" y1="-2.5908" x2="-2.0828" y2="-2.5908" width="0.1524" layer="39"/>
-<wire x1="-2.0828" y1="-2.5908" x2="-2.0828" y2="-2.2352" width="0.1524" layer="39"/>
-<wire x1="-3.3528" y1="-2.2352" x2="-2.0828" y2="-2.2352" width="0.1524" layer="39"/>
-<polygon width="0.1524" layer="39">
-<vertex x="-3.3528" y="-2.2479"/>
-<vertex x="-3.3528" y="2.2479"/>
-<vertex x="-2.0955" y="2.2479"/>
-<vertex x="-2.0955" y="2.6035"/>
-<vertex x="2.0955" y="2.6035"/>
-<vertex x="2.0955" y="2.2479"/>
-<vertex x="3.3528" y="2.2479"/>
-<vertex x="3.3528" y="-2.2479"/>
-<vertex x="2.0955" y="-2.2479"/>
-<vertex x="2.0955" y="-2.6035"/>
-<vertex x="-2.0955" y="-2.6035"/>
-<vertex x="-2.0955" y="-2.2479"/>
-</polygon>
-<wire x1="-2.1336" y1="-2.6416" x2="2.1336" y2="-2.6416" width="0.1524" layer="21"/>
-<wire x1="2.1336" y1="2.6416" x2="-2.1336" y2="2.6416" width="0.1524" layer="21"/>
-<text x="-3.2512" y="2.2606" size="1.27" layer="21" ratio="6" rot="SR0">*</text>
-<wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
-<wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
-<text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+<package name="TEENSY_3.6_SIMPLE">
+<pad name="AGND" x="16.51" y="57.15" drill="0.8" shape="long"/>
+<pad name="D13" x="16.51" y="26.67" drill="0.8" shape="long"/>
+<pad name="A0" x="16.51" y="29.21" drill="0.8" shape="long"/>
+<pad name="A1" x="16.51" y="31.75" drill="0.8" shape="long"/>
+<pad name="A2" x="16.51" y="34.29" drill="0.8" shape="long"/>
+<pad name="A3" x="16.51" y="36.83" drill="0.8" shape="long"/>
+<pad name="A4" x="16.51" y="39.37" drill="0.8" shape="long"/>
+<pad name="A5" x="16.51" y="41.91" drill="0.8" shape="long"/>
+<pad name="A6" x="16.51" y="44.45" drill="0.8" shape="long"/>
+<pad name="A7" x="16.51" y="46.99" drill="0.8" shape="long"/>
+<pad name="A8" x="16.51" y="49.53" drill="0.8" shape="long"/>
+<pad name="D12" x="1.27" y="26.67" drill="0.8" shape="long"/>
+<pad name="D11" x="1.27" y="29.21" drill="0.8" shape="long"/>
+<pad name="D5" x="1.27" y="44.45" drill="0.8" shape="long"/>
+<pad name="D4(CANRX)" x="1.27" y="46.99" drill="0.8" shape="long"/>
+<pad name="D3(CANTX)" x="1.27" y="49.53" drill="0.8" shape="long"/>
+<pad name="D2" x="1.27" y="52.07" drill="0.8" shape="long"/>
+<pad name="GND" x="1.27" y="59.69" drill="0.8" shape="long"/>
+<pad name="VIN" x="16.51" y="59.69" drill="0.8" shape="long"/>
+<pad name="3.3V2" x="16.51" y="54.61" drill="0.8" shape="long"/>
+<pad name="A9" x="16.51" y="52.07" drill="0.8" shape="long"/>
+<pad name="D0(RX1)" x="1.27" y="57.15" drill="0.8" shape="long" rot="R180"/>
+<pad name="D1(TX1)" x="1.27" y="54.61" drill="0.8" shape="long" rot="R180"/>
+<pad name="D10(TX2)" x="1.27" y="31.75" drill="0.8" shape="long"/>
+<pad name="D6" x="1.27" y="41.91" drill="0.8" shape="long" rot="R180"/>
+<pad name="D7(RX3)" x="1.27" y="39.37" drill="0.8" shape="long" rot="R180"/>
+<pad name="D8(TX3)" x="1.27" y="36.83" drill="0.8" shape="long" rot="R180"/>
+<pad name="D9(RX2)" x="1.27" y="34.29" drill="0.8" shape="long" rot="R180"/>
+<wire x1="17.78" y1="60.96" x2="17.78" y2="0" width="0.127" layer="21"/>
+<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="61.722" x2="12.7" y2="61.722" width="0.127" layer="21"/>
+<wire x1="12.7" y1="61.722" x2="12.7" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="60.96" x2="5.08" y2="61.722" width="0.127" layer="21"/>
+<wire x1="0" y1="60.96" x2="5.08" y2="60.96" width="0.127" layer="21"/>
+<wire x1="12.7" y1="60.96" x2="17.78" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="60.96" x2="5.08" y2="55.88" width="0.127" layer="21"/>
+<wire x1="5.08" y1="55.88" x2="12.7" y2="55.88" width="0.127" layer="21"/>
+<wire x1="12.7" y1="55.88" x2="12.7" y2="60.96" width="0.127" layer="21"/>
+<pad name="3.3V" x="1.27" y="24.13" drill="0.8" shape="long"/>
+<pad name="D24" x="1.27" y="21.59" drill="0.8" shape="long"/>
+<pad name="D25" x="1.27" y="19.05" drill="0.8" shape="long"/>
+<pad name="D26" x="1.27" y="16.51" drill="0.8" shape="long"/>
+<pad name="D27" x="1.27" y="13.97" drill="0.8" shape="long"/>
+<pad name="D28" x="1.27" y="11.43" drill="0.8" shape="long"/>
+<pad name="D29" x="1.27" y="8.89" drill="0.8" shape="long"/>
+<pad name="D30" x="1.27" y="6.35" drill="0.8" shape="long"/>
+<pad name="A12" x="1.27" y="3.81" drill="0.8" shape="long"/>
+<pad name="A13" x="1.27" y="1.27" drill="0.8" shape="long"/>
+<pad name="GND2" x="16.51" y="24.13" drill="0.8" shape="long"/>
+<pad name="A22" x="16.51" y="21.59" drill="0.8" shape="long"/>
+<pad name="A21" x="16.51" y="19.05" drill="0.8" shape="long"/>
+<pad name="A20" x="16.51" y="16.51" drill="0.8" shape="long"/>
+<pad name="A19" x="16.51" y="13.97" drill="0.8" shape="long"/>
+<pad name="A18" x="16.51" y="11.43" drill="0.8" shape="long"/>
+<pad name="A17" x="16.51" y="8.89" drill="0.8" shape="long"/>
+<pad name="A16" x="16.51" y="6.35" drill="0.8" shape="long"/>
+<pad name="A15" x="16.51" y="3.81" drill="0.8" shape="long"/>
+<pad name="A14" x="16.51" y="1.27" drill="0.8" shape="long"/>
+<text x="8.89" y="58.7375" size="2.54" layer="21" align="center">3.6</text>
 </package>
-<package name="PCC-SMP">
-<description>&lt;b&gt;PCC-SMP&lt;/b&gt;&lt;br&gt;
-</description>
-<pad name="1" x="2.25" y="6.85" drill="1.77" diameter="2.7"/>
-<pad name="2" x="2.25" y="-6.85" drill="1.77" diameter="2.7"/>
-<pad name="3" x="15.75" y="7.85" drill="1.77" diameter="2.7"/>
-<pad name="4" x="15.75" y="-7.85" drill="1.77" diameter="2.7"/>
-<text x="7.85763125" y="0.02243125" size="1.27" layer="25" align="center">&gt;NAME</text>
-<text x="7.85763125" y="0.02243125" size="1.27" layer="27" align="center">&gt;VALUE</text>
-<wire x1="0" y1="7.75" x2="20.8" y2="7.75" width="0.2" layer="51"/>
-<wire x1="20.8" y1="7.75" x2="20.8" y2="-7.75" width="0.2" layer="51"/>
-<wire x1="20.8" y1="-7.75" x2="0" y2="-7.75" width="0.2" layer="51"/>
-<wire x1="0" y1="-7.75" x2="0" y2="7.75" width="0.2" layer="51"/>
-<wire x1="0" y1="7.75" x2="0" y2="-7.75" width="0.2" layer="21"/>
-<wire x1="20.8" y1="-7.75" x2="20.8" y2="7.75" width="0.2" layer="21"/>
-<wire x1="20.8" y1="7.75" x2="17.4" y2="7.75" width="0.2" layer="21"/>
-<wire x1="3.517" y1="7.75" x2="14.1" y2="7.75" width="0.2" layer="21"/>
-<wire x1="3.517" y1="-7.75" x2="14.1" y2="-7.75" width="0.2" layer="21"/>
-<wire x1="20.8" y1="-7.75" x2="17.4" y2="-7.75" width="0.2" layer="21"/>
-<circle x="-0.721" y="6.932" radius="0.111" width="0.2" layer="25"/>
+<package name="XP-E2">
+<description>&lt;b&gt;Cree® XLamp® XP-E2 LEDs&lt;/b&gt;&lt;p&gt;
+&lt;a href="https://www.cree.com/led-components/media/documents/XLampXPE2.pdf"&gt;Source: www.cree.com/xlamp .. XLampXP-E2.pdf&lt;/a&gt;</description>
+<circle x="-2.0574" y="-2.0574" radius="0.1524" width="0" layer="51"/>
+<circle x="0" y="0" radius="1.25" width="0.2032" layer="51"/>
+<wire x1="-1.778" y1="1.778" x2="1.778" y2="1.778" width="0.2032" layer="51"/>
+<wire x1="1.778" y1="1.778" x2="1.778" y2="-1.778" width="0.2032" layer="51"/>
+<wire x1="1.778" y1="-1.778" x2="-1.778" y2="-1.778" width="0.2032" layer="51"/>
+<wire x1="-1.778" y1="-1.778" x2="-1.778" y2="1.778" width="0.2032" layer="51"/>
+<wire x1="-1.525" y1="0" x2="-1.15" y2="0" width="0.1016" layer="51"/>
+<wire x1="-1.325" y1="0.175" x2="-1.325" y2="-0.175" width="0.1016" layer="51"/>
+<rectangle x1="-0.5005" y1="-0.375" x2="0.5005" y2="0.375" layer="31"/>
+<rectangle x1="-1.65" y1="-1.65" x2="-1.15" y2="1.65" layer="31"/>
+<rectangle x1="1.15" y1="-1.65" x2="1.65" y2="1.65" layer="31"/>
+<rectangle x1="-0.5005" y1="0.625" x2="0.5005" y2="1.375" layer="31"/>
+<rectangle x1="-0.5005" y1="-1.375" x2="0.5005" y2="-0.625" layer="31"/>
+<smd name="A" x="-1.4" y="0" dx="0.5" dy="3.3" layer="1" cream="no"/>
+<smd name="C" x="1.4" y="0" dx="0.5" dy="3.3" layer="1" cream="no"/>
+<smd name="X" x="0" y="0" dx="1.3" dy="3.3" layer="1" cream="no"/>
+<text x="-2.54" y="-3.81" size="1.27" layer="25" font="vector">&gt;NAME</text>
+<text x="-2.54" y="2.54" size="1.27" layer="27" font="vector">&gt;VALUE</text>
+</package>
+<package name="TEENSY_3.5_EXT_RTC">
+<pad name="AGND" x="16.51" y="57.15" drill="0.8" shape="long"/>
+<pad name="D13" x="16.51" y="26.67" drill="0.8" shape="long"/>
+<pad name="A0" x="16.51" y="29.21" drill="0.8" shape="long"/>
+<pad name="A1" x="16.51" y="31.75" drill="0.8" shape="long"/>
+<pad name="A2" x="16.51" y="34.29" drill="0.8" shape="long"/>
+<pad name="A3" x="16.51" y="36.83" drill="0.8" shape="long"/>
+<pad name="A4" x="16.51" y="39.37" drill="0.8" shape="long"/>
+<pad name="A5" x="16.51" y="41.91" drill="0.8" shape="long"/>
+<pad name="A6" x="16.51" y="44.45" drill="0.8" shape="long"/>
+<pad name="A7" x="16.51" y="46.99" drill="0.8" shape="long"/>
+<pad name="A8" x="16.51" y="49.53" drill="0.8" shape="long"/>
+<pad name="D12" x="1.27" y="26.67" drill="0.8" shape="long"/>
+<pad name="D11" x="1.27" y="29.21" drill="0.8" shape="long"/>
+<pad name="D5" x="1.27" y="44.45" drill="0.8" shape="long"/>
+<pad name="D4(CANRX)" x="1.27" y="46.99" drill="0.8" shape="long"/>
+<pad name="D3(CANTX)" x="1.27" y="49.53" drill="0.8" shape="long"/>
+<pad name="D2" x="1.27" y="52.07" drill="0.8" shape="long"/>
+<pad name="GND" x="1.27" y="59.69" drill="0.8" shape="long"/>
+<pad name="VIN" x="16.51" y="59.69" drill="0.8" shape="long"/>
+<pad name="3.3V3" x="16.51" y="54.61" drill="0.8" shape="long"/>
+<pad name="A9" x="16.51" y="52.07" drill="0.8" shape="long"/>
+<pad name="D0(RX1)" x="1.27" y="57.15" drill="0.8" shape="long" rot="R180"/>
+<pad name="D1(TX1)" x="1.27" y="54.61" drill="0.8" shape="long" rot="R180"/>
+<pad name="D10(TX2)" x="1.27" y="31.75" drill="0.8" shape="long"/>
+<pad name="D6" x="1.27" y="41.91" drill="0.8" shape="long" rot="R180"/>
+<pad name="D7(RX3)" x="1.27" y="39.37" drill="0.8" shape="long" rot="R180"/>
+<pad name="D8(TX3)" x="1.27" y="36.83" drill="0.8" shape="long" rot="R180"/>
+<pad name="D9(RX2)" x="1.27" y="34.29" drill="0.8" shape="long" rot="R180"/>
+<wire x1="17.78" y1="60.96" x2="17.78" y2="0" width="0.127" layer="21"/>
+<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="61.722" x2="12.7" y2="61.722" width="0.127" layer="21"/>
+<wire x1="12.7" y1="61.722" x2="12.7" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="60.96" x2="5.08" y2="61.722" width="0.127" layer="21"/>
+<wire x1="0" y1="60.96" x2="5.08" y2="60.96" width="0.127" layer="21"/>
+<wire x1="12.7" y1="60.96" x2="17.78" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="60.96" x2="5.08" y2="55.88" width="0.127" layer="21"/>
+<wire x1="5.08" y1="55.88" x2="12.7" y2="55.88" width="0.127" layer="21"/>
+<wire x1="12.7" y1="55.88" x2="12.7" y2="60.96" width="0.127" layer="21"/>
+<pad name="3.3V" x="1.27" y="24.13" drill="0.8" shape="long"/>
+<pad name="D24" x="1.27" y="21.59" drill="0.8" shape="long"/>
+<pad name="D25" x="1.27" y="19.05" drill="0.8" shape="long"/>
+<pad name="D26" x="1.27" y="16.51" drill="0.8" shape="long"/>
+<pad name="D27" x="1.27" y="13.97" drill="0.8" shape="long"/>
+<pad name="D28" x="1.27" y="11.43" drill="0.8" shape="long"/>
+<pad name="D29" x="1.27" y="8.89" drill="0.8" shape="long"/>
+<pad name="D30" x="1.27" y="6.35" drill="0.8" shape="long"/>
+<pad name="A12" x="1.27" y="3.81" drill="0.8" shape="long"/>
+<pad name="A13" x="1.27" y="1.27" drill="0.8" shape="long"/>
+<pad name="GND3" x="16.51" y="24.13" drill="0.8" shape="long"/>
+<pad name="A22" x="16.51" y="21.59" drill="0.8" shape="long"/>
+<pad name="A21" x="16.51" y="19.05" drill="0.8" shape="long"/>
+<pad name="A20" x="16.51" y="16.51" drill="0.8" shape="long"/>
+<pad name="A19" x="16.51" y="13.97" drill="0.8" shape="long"/>
+<pad name="A18" x="16.51" y="11.43" drill="0.8" shape="long"/>
+<pad name="A17" x="16.51" y="8.89" drill="0.8" shape="long"/>
+<pad name="A16" x="16.51" y="6.35" drill="0.8" shape="long"/>
+<pad name="A15" x="16.51" y="3.81" drill="0.8" shape="long"/>
+<pad name="A14" x="16.51" y="1.27" drill="0.8" shape="long"/>
+<pad name="VBAT" x="3.81" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<pad name="3.3V2" x="6.35" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<pad name="GND2" x="8.89" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<pad name="PRGM" x="11.43" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<pad name="RST" x="13.97" y="13.97" drill="0.8" shape="long" rot="R90"/>
+<text x="8.89" y="58.7375" size="2.54" layer="21" align="center">3.5</text>
 </package>
 <package name="SSOP-16_GN">
 <smd name="1" x="-2.4638" y="2.2225" dx="1.9812" dy="0.3556" layer="1"/>
@@ -11024,130 +10809,392 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
 <text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
 </package>
-<package name="SSOP-16_GN-M">
-<smd name="1" x="-2.5146" y="2.2225" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="2" x="-2.5146" y="1.5875" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="3" x="-2.5146" y="0.9525" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="4" x="-2.5146" y="0.3175" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="5" x="-2.5146" y="-0.3175" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="6" x="-2.5146" y="-0.9525" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="7" x="-2.5146" y="-1.5875" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="8" x="-2.5146" y="-2.2225" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="9" x="2.5146" y="-2.2225" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="10" x="2.5146" y="-1.5875" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="11" x="2.5146" y="-0.9525" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="12" x="2.5146" y="-0.3175" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="13" x="2.5146" y="0.3175" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="14" x="2.5146" y="0.9525" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="15" x="2.5146" y="1.5875" dx="2.286" dy="0.4064" layer="1"/>
-<smd name="16" x="2.5146" y="2.2225" dx="2.286" dy="0.4064" layer="1"/>
-<wire x1="-1.9812" y1="2.0828" x2="-2.0066" y2="2.3876" width="0.1524" layer="51"/>
-<wire x1="-2.0066" y1="2.3876" x2="-3.0988" y2="2.3622" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="2.3622" x2="-3.0988" y2="2.0574" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="2.0574" x2="-1.9812" y2="2.0828" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="1.4224" x2="-2.0066" y2="1.7272" width="0.1524" layer="51"/>
-<wire x1="-2.0066" y1="1.7272" x2="-3.0988" y2="1.7272" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="1.7272" x2="-3.0988" y2="1.4224" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="1.4224" x2="-1.9812" y2="1.4224" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="0.8128" x2="-1.9812" y2="1.1176" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="1.1176" x2="-3.0988" y2="1.0922" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="1.0922" x2="-3.0988" y2="0.7874" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="0.7874" x2="-1.9812" y2="0.8128" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="0.1524" x2="-1.9812" y2="0.4572" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="0.4572" x2="-3.0988" y2="0.4572" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="0.4572" x2="-3.0988" y2="0.1524" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="0.1524" x2="-1.9812" y2="0.1524" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-0.4572" x2="-1.9812" y2="-0.1524" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-0.1524" x2="-3.0988" y2="-0.1778" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-0.1778" x2="-3.0988" y2="-0.4826" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-0.4826" x2="-1.9812" y2="-0.4572" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-1.1176" x2="-1.9812" y2="-0.8128" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-0.8128" x2="-3.0988" y2="-0.8128" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-0.8128" x2="-3.0988" y2="-1.1176" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-1.1176" x2="-1.9812" y2="-1.1176" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-1.7272" x2="-1.9812" y2="-1.4224" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-1.4224" x2="-3.0988" y2="-1.4478" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-1.4478" x2="-3.0988" y2="-1.7526" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-1.7526" x2="-1.9812" y2="-1.7272" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-2.3876" x2="-1.9812" y2="-2.0828" width="0.1524" layer="51"/>
-<wire x1="-1.9812" y1="-2.0828" x2="-3.0988" y2="-2.0828" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-2.0828" x2="-3.0988" y2="-2.3876" width="0.1524" layer="51"/>
-<wire x1="-3.0988" y1="-2.3876" x2="-1.9812" y2="-2.3876" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-2.0828" x2="2.0066" y2="-2.3876" width="0.1524" layer="51"/>
-<wire x1="2.0066" y1="-2.3876" x2="3.0988" y2="-2.3622" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-2.3622" x2="3.0988" y2="-2.0574" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-2.0574" x2="1.9812" y2="-2.0828" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-1.4224" x2="1.9812" y2="-1.7272" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-1.7272" x2="3.0988" y2="-1.7272" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-1.7272" x2="3.0988" y2="-1.4224" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-1.4224" x2="1.9812" y2="-1.4224" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-0.8128" x2="1.9812" y2="-1.1176" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-1.1176" x2="3.0988" y2="-1.0922" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-1.0922" x2="3.0988" y2="-0.7874" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-0.7874" x2="1.9812" y2="-0.8128" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-0.1524" x2="1.9812" y2="-0.4572" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="-0.4572" x2="3.0988" y2="-0.4572" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-0.4572" x2="3.0988" y2="-0.1524" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="-0.1524" x2="1.9812" y2="-0.1524" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="0.4572" x2="1.9812" y2="0.1524" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="0.1524" x2="3.0988" y2="0.1778" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="0.1778" x2="3.0988" y2="0.4826" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="0.4826" x2="1.9812" y2="0.4572" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="1.1176" x2="1.9812" y2="0.8128" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="0.8128" x2="3.0988" y2="0.8128" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="0.8128" x2="3.0988" y2="1.1176" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="1.1176" x2="1.9812" y2="1.1176" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="1.7272" x2="1.9812" y2="1.4224" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="1.4224" x2="3.0988" y2="1.4478" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="1.4478" x2="3.0988" y2="1.7526" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="1.7526" x2="1.9812" y2="1.7272" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="2.3876" x2="1.9812" y2="2.0828" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="2.0828" x2="3.0988" y2="2.0828" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="2.0828" x2="3.0988" y2="2.3876" width="0.1524" layer="51"/>
-<wire x1="3.0988" y1="2.3876" x2="1.9812" y2="2.3876" width="0.1524" layer="51"/>
+<package name="MSOP-8_MS-M">
+<smd name="1" x="-2.2606" y="0.975" dx="1.7018" dy="0.4826" layer="1"/>
+<smd name="2" x="-2.2606" y="0.325" dx="1.7018" dy="0.4826" layer="1"/>
+<smd name="3" x="-2.2606" y="-0.325" dx="1.7018" dy="0.4826" layer="1"/>
+<smd name="4" x="-2.2606" y="-0.975" dx="1.7018" dy="0.4826" layer="1"/>
+<smd name="5" x="2.2606" y="-0.975" dx="1.7018" dy="0.4826" layer="1"/>
+<smd name="6" x="2.2606" y="-0.325" dx="1.7018" dy="0.4826" layer="1"/>
+<smd name="7" x="2.2606" y="0.325" dx="1.7018" dy="0.4826" layer="1"/>
+<smd name="8" x="2.2606" y="0.975" dx="1.7018" dy="0.4826" layer="1"/>
+<wire x1="-1.5494" y1="0.7874" x2="-1.5494" y2="1.1684" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="1.1684" x2="-2.54" y2="1.1684" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="1.1684" x2="-2.54" y2="0.7874" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="0.7874" x2="-1.5494" y2="0.7874" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="0.127" x2="-1.5494" y2="0.508" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="0.508" x2="-2.54" y2="0.508" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="0.508" x2="-2.54" y2="0.127" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="0.127" x2="-1.5494" y2="0.127" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="-0.508" x2="-1.5494" y2="-0.127" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="-0.127" x2="-2.54" y2="-0.127" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="-0.127" x2="-2.54" y2="-0.508" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="-0.508" x2="-1.5494" y2="-0.508" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="-1.1684" x2="-1.5494" y2="-0.7874" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="-0.7874" x2="-2.54" y2="-0.7874" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="-0.7874" x2="-2.54" y2="-1.1684" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="-1.1684" x2="-1.5494" y2="-1.1684" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="-0.7874" x2="1.5494" y2="-1.1684" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="-1.1684" x2="2.54" y2="-1.1684" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="-1.1684" x2="2.54" y2="-0.7874" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="-0.7874" x2="1.5494" y2="-0.7874" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="-0.127" x2="1.5494" y2="-0.508" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="-0.508" x2="2.54" y2="-0.508" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="-0.508" x2="2.54" y2="-0.127" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="-0.127" x2="1.5494" y2="-0.127" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="0.508" x2="1.5494" y2="0.127" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="0.127" x2="2.54" y2="0.127" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="0.127" x2="2.54" y2="0.508" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="0.508" x2="1.5494" y2="0.508" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="1.1684" x2="1.5494" y2="0.7874" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="0.7874" x2="2.54" y2="0.7874" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="0.7874" x2="2.54" y2="1.1684" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="1.1684" x2="1.5494" y2="1.1684" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="-1.5494" x2="1.5494" y2="-1.5494" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="-1.5494" x2="1.5494" y2="1.5494" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="1.5494" x2="0.3048" y2="1.5494" width="0.1524" layer="51"/>
+<wire x1="0.3048" y1="1.5494" x2="-0.3048" y2="1.5494" width="0.1524" layer="51"/>
+<wire x1="-0.3048" y1="1.5494" x2="-1.5494" y2="1.5494" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="1.5494" x2="-1.5494" y2="-1.5494" width="0.1524" layer="51"/>
+<wire x1="0.3048" y1="1.5494" x2="-0.3048" y2="1.5494" width="0.1524" layer="51" curve="-180"/>
+<text x="-1.7526" y="0.2032" size="1.27" layer="51" ratio="6" rot="SR0">*</text>
+<wire x1="-3.6068" y1="-1.7272" x2="-3.6068" y2="1.7272" width="0.1524" layer="39"/>
+<wire x1="-3.6068" y1="1.7272" x2="-2.0574" y2="1.7272" width="0.1524" layer="39"/>
+<wire x1="-2.0574" y1="1.7272" x2="-2.0574" y2="2.0574" width="0.1524" layer="39"/>
+<wire x1="-2.0574" y1="2.0574" x2="2.0574" y2="2.0574" width="0.1524" layer="39"/>
+<wire x1="2.0574" y1="2.0574" x2="2.0574" y2="1.7272" width="0.1524" layer="39"/>
+<wire x1="3.6068" y1="1.7272" x2="2.0574" y2="1.7272" width="0.1524" layer="39"/>
+<wire x1="3.6068" y1="1.7272" x2="3.6068" y2="-1.7272" width="0.1524" layer="39"/>
+<wire x1="3.6068" y1="-1.7272" x2="2.0574" y2="-1.7272" width="0.1524" layer="39"/>
+<wire x1="2.0574" y1="-1.7272" x2="2.0574" y2="-2.0574" width="0.1524" layer="39"/>
+<wire x1="2.0574" y1="-2.0574" x2="-2.0574" y2="-2.0574" width="0.1524" layer="39"/>
+<wire x1="-2.0574" y1="-2.0574" x2="-2.0574" y2="-1.7272" width="0.1524" layer="39"/>
+<wire x1="-3.6068" y1="-1.7272" x2="-2.0574" y2="-1.7272" width="0.1524" layer="39"/>
+<polygon width="0.1524" layer="39">
+<vertex x="-3.6195" y="-1.7243"/>
+<vertex x="-3.6195" y="1.7243"/>
+<vertex x="-2.0574" y="1.7243"/>
+<vertex x="-2.0574" y="2.0574"/>
+<vertex x="2.0574" y="2.0574"/>
+<vertex x="2.0574" y="1.7243"/>
+<vertex x="3.6195" y="1.7243"/>
+<vertex x="3.6195" y="-1.7243"/>
+<vertex x="2.0574" y="-1.7243"/>
+<vertex x="2.0574" y="-2.0574"/>
+<vertex x="-2.0574" y="-2.0574"/>
+<vertex x="-2.0574" y="-1.7243"/>
+</polygon>
+<wire x1="-1.6764" y1="-1.6764" x2="1.6764" y2="-1.6764" width="0.1524" layer="21"/>
+<wire x1="1.6764" y1="1.6764" x2="-1.6764" y2="1.6764" width="0.1524" layer="21"/>
+<text x="-3.0988" y="1.3208" size="1.27" layer="21" ratio="6" rot="SR0">*</text>
+<wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
+<wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
+<text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+</package>
+<package name="AMPHENOL_10118192-0001LF">
+<wire x1="-3.75" y1="0.225" x2="3.75" y2="0.225" width="0.127" layer="51"/>
+<wire x1="3.75" y1="0.225" x2="3.75" y2="-4.125" width="0.127" layer="51"/>
+<wire x1="3.75" y1="-4.125" x2="3.75" y2="-5.436" width="0.127" layer="51"/>
+<wire x1="3.75" y1="-5.436" x2="-3.75" y2="-5.436" width="0.127" layer="51"/>
+<wire x1="-3.75" y1="-5.436" x2="-3.75" y2="-4.125" width="0.127" layer="51"/>
+<wire x1="-3.75" y1="-4.125" x2="-3.75" y2="0.225" width="0.127" layer="51"/>
+<wire x1="3.75" y1="-4.125" x2="-3.75" y2="-4.125" width="0.127" layer="51"/>
+<wire x1="3.75" y1="-4.125" x2="7.15" y2="-4.125" width="0.127" layer="51"/>
+<text x="5.204959375" y="-3.90371875" size="0.813575" layer="51">PCB Edge</text>
+<wire x1="-3.75" y1="-1.15" x2="-3.75" y2="-1.5" width="0.127" layer="21"/>
+<wire x1="3.75" y1="-1.15" x2="3.75" y2="-1.5" width="0.127" layer="21"/>
+<wire x1="-3.75" y1="-3.85" x2="-3.75" y2="-4.125" width="0.127" layer="21"/>
+<wire x1="-3.75" y1="-4.125" x2="3.75" y2="-4.125" width="0.127" layer="21"/>
+<wire x1="3.75" y1="-4.125" x2="3.75" y2="-3.85" width="0.127" layer="21"/>
+<wire x1="-1.83" y1="0.225" x2="-1.72" y2="0.225" width="0.127" layer="21"/>
+<wire x1="1.72" y1="0.225" x2="1.83" y2="0.225" width="0.127" layer="21"/>
+<wire x1="-4.95" y1="0.925" x2="4.95" y2="0.925" width="0.05" layer="39"/>
+<wire x1="4.95" y1="0.925" x2="4.95" y2="-5.686" width="0.05" layer="39"/>
+<wire x1="4.95" y1="-5.686" x2="-4.95" y2="-5.686" width="0.05" layer="39"/>
+<wire x1="-4.95" y1="-5.686" x2="-4.95" y2="0.925" width="0.05" layer="39"/>
+<circle x="-1.4" y="1.3" radius="0.1" width="0.3" layer="21"/>
+<circle x="-1.4" y="1.3" radius="0.1" width="0.3" layer="51"/>
+<text x="-4.953109375" y="1.778040625" size="1.00001875" layer="25">&gt;NAME</text>
+<text x="-5.080290625" y="-6.350359375" size="1.000059375" layer="27">&gt;VALUE</text>
+<smd name="3" x="0" y="0" dx="0.4" dy="1.35" layer="1"/>
+<smd name="2" x="-0.65" y="0" dx="0.4" dy="1.35" layer="1"/>
+<smd name="4" x="0.65" y="0" dx="0.4" dy="1.35" layer="1"/>
+<smd name="1" x="-1.3" y="0" dx="0.4" dy="1.35" layer="1"/>
+<smd name="5" x="1.3" y="0" dx="0.4" dy="1.35" layer="1"/>
+<smd name="SH1" x="-3.1" y="-0.125" dx="2.1" dy="1.6" layer="1"/>
+<smd name="SH2" x="3.1" y="-0.125" dx="2.1" dy="1.6" layer="1"/>
+<smd name="SH3" x="-3.8" y="-2.675" dx="1.8" dy="1.9" layer="1" rot="R180"/>
+<smd name="SH6" x="3.8" y="-2.675" dx="1.8" dy="1.9" layer="1" rot="R180"/>
+<smd name="SH4" x="-1.2" y="-2.675" dx="1.9" dy="1.9" layer="1"/>
+<smd name="SH5" x="1.2" y="-2.675" dx="1.9" dy="1.9" layer="1"/>
+</package>
+<package name="TEENSY_LC_EXT">
+<pad name="AGND" x="16.51" y="31.75" drill="0.8" shape="long"/>
+<pad name="D13" x="16.51" y="1.27" drill="0.8" shape="long"/>
+<pad name="A0" x="16.51" y="3.81" drill="0.8" shape="long"/>
+<pad name="A1" x="16.51" y="6.35" drill="0.8" shape="long"/>
+<pad name="A2" x="16.51" y="8.89" drill="0.8" shape="long"/>
+<pad name="A3" x="16.51" y="11.43" drill="0.8" shape="long"/>
+<pad name="A4" x="16.51" y="13.97" drill="0.8" shape="long"/>
+<pad name="A5" x="16.51" y="16.51" drill="0.8" shape="long"/>
+<pad name="A6" x="16.51" y="19.05" drill="0.8" shape="long"/>
+<pad name="A7" x="16.51" y="21.59" drill="0.8" shape="long"/>
+<pad name="A8" x="16.51" y="24.13" drill="0.8" shape="long"/>
+<pad name="D12" x="1.27" y="1.27" drill="0.8" shape="long"/>
+<pad name="D11" x="1.27" y="3.81" drill="0.8" shape="long"/>
+<pad name="D5" x="1.27" y="19.05" drill="0.8" shape="long"/>
+<pad name="D4" x="1.27" y="21.59" drill="0.8" shape="long"/>
+<pad name="D3" x="1.27" y="24.13" drill="0.8" shape="long"/>
+<pad name="D2" x="1.27" y="26.67" drill="0.8" shape="long"/>
+<pad name="GND" x="1.27" y="34.29" drill="0.8" shape="long"/>
+<pad name="VIN" x="16.51" y="34.29" drill="0.8" shape="long"/>
+<pad name="3.3V2" x="16.51" y="29.21" drill="0.8" shape="long"/>
+<pad name="A9" x="16.51" y="26.67" drill="0.8" shape="long"/>
+<pad name="D0(RX1)" x="1.27" y="31.75" drill="0.8" shape="long" rot="R180"/>
+<pad name="D1(TX1)" x="1.27" y="29.21" drill="0.8" shape="long" rot="R180"/>
+<pad name="D10(TX2)" x="1.27" y="6.35" drill="0.8" shape="long"/>
+<pad name="D6" x="1.27" y="16.51" drill="0.8" shape="long" rot="R180"/>
+<pad name="D7(RX3)" x="1.27" y="13.97" drill="0.8" shape="long" rot="R180"/>
+<pad name="D8(TX3)" x="1.27" y="11.43" drill="0.8" shape="long" rot="R180"/>
+<pad name="D9(RX2)" x="1.27" y="8.89" drill="0.8" shape="long" rot="R180"/>
+<wire x1="17.78" y1="35.56" x2="17.78" y2="0" width="0.127" layer="21"/>
+<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="36.322" x2="12.7" y2="36.322" width="0.127" layer="21"/>
+<wire x1="12.7" y1="36.322" x2="12.7" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="35.56" x2="5.08" y2="36.322" width="0.127" layer="21"/>
+<wire x1="0" y1="35.56" x2="5.08" y2="35.56" width="0.127" layer="21"/>
+<wire x1="12.7" y1="35.56" x2="17.78" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="35.56" x2="5.08" y2="30.48" width="0.127" layer="21"/>
+<wire x1="5.08" y1="30.48" x2="12.7" y2="30.48" width="0.127" layer="21"/>
+<wire x1="12.7" y1="30.48" x2="12.7" y2="35.56" width="0.127" layer="21"/>
+<pad name="D17" x="3.81" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<pad name="3.3V" x="6.35" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<pad name="GND2" x="8.89" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<pad name="PGRM" x="11.43" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<pad name="DAC" x="13.97" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<text x="9.2075" y="33.3375" size="2.54" layer="21" align="center">LC</text>
+</package>
+<package name="21-0041B_8">
+<smd name="1" x="-2.4638" y="1.905" dx="1.9812" dy="0.5334" layer="1"/>
+<smd name="2" x="-2.4638" y="0.635" dx="1.9812" dy="0.5334" layer="1"/>
+<smd name="3" x="-2.4638" y="-0.635" dx="1.9812" dy="0.5334" layer="1"/>
+<smd name="4" x="-2.4638" y="-1.905" dx="1.9812" dy="0.5334" layer="1"/>
+<smd name="5" x="2.4638" y="-1.905" dx="1.9812" dy="0.5334" layer="1"/>
+<smd name="6" x="2.4638" y="-0.635" dx="1.9812" dy="0.5334" layer="1"/>
+<smd name="7" x="2.4638" y="0.635" dx="1.9812" dy="0.5334" layer="1"/>
+<smd name="8" x="2.4638" y="1.905" dx="1.9812" dy="0.5334" layer="1"/>
+<wire x1="-1.9812" y1="1.6764" x2="-2.0066" y2="2.1336" width="0.1524" layer="51"/>
+<wire x1="-2.0066" y1="2.1336" x2="-3.0988" y2="2.1336" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="2.1336" x2="-3.0988" y2="1.651" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="1.651" x2="-1.9812" y2="1.6764" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="0.4064" x2="-2.0066" y2="0.8636" width="0.1524" layer="51"/>
+<wire x1="-2.0066" y1="0.8636" x2="-3.0988" y2="0.8636" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="0.8636" x2="-3.0988" y2="0.381" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="0.381" x2="-1.9812" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-0.8636" x2="-1.9812" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-0.4064" x2="-3.0988" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-0.4064" x2="-3.0988" y2="-0.889" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-0.889" x2="-1.9812" y2="-0.8636" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-2.1336" x2="-1.9812" y2="-1.6764" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-1.6764" x2="-3.0988" y2="-1.6764" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-1.6764" x2="-3.0988" y2="-2.159" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-2.159" x2="-1.9812" y2="-2.1336" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-1.6764" x2="2.0066" y2="-2.1336" width="0.1524" layer="51"/>
+<wire x1="2.0066" y1="-2.1336" x2="3.0988" y2="-2.1336" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-2.1336" x2="3.0988" y2="-1.651" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-1.651" x2="1.9812" y2="-1.6764" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-0.4064" x2="1.9812" y2="-0.8636" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-0.8636" x2="3.0988" y2="-0.8636" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-0.8636" x2="3.0988" y2="-0.381" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-0.381" x2="1.9812" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="0.8636" x2="1.9812" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="0.4064" x2="3.0988" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="0.4064" x2="3.0988" y2="0.889" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="0.889" x2="1.9812" y2="0.8636" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="2.1336" x2="1.9812" y2="1.6764" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="1.6764" x2="3.0988" y2="1.6764" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="1.6764" x2="3.0988" y2="2.159" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="2.159" x2="1.9812" y2="2.1336" width="0.1524" layer="51"/>
 <wire x1="-1.9812" y1="-2.4892" x2="1.9812" y2="-2.4892" width="0.1524" layer="51"/>
 <wire x1="1.9812" y1="-2.4892" x2="1.9812" y2="2.4892" width="0.1524" layer="51"/>
-<wire x1="1.9812" y1="2.4892" x2="0.3048" y2="2.4892" width="0.1524" layer="51"/>
-<wire x1="0.3048" y1="2.4892" x2="-0.3048" y2="2.4892" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="2.4892" x2="-0.3048" y2="2.4892" width="0.1524" layer="51"/>
 <wire x1="-0.3048" y1="2.4892" x2="-1.9812" y2="2.4892" width="0.1524" layer="51"/>
 <wire x1="-1.9812" y1="2.4892" x2="-1.9812" y2="-2.4892" width="0.1524" layer="51"/>
-<wire x1="0.3048" y1="2.4892" x2="-0.3048" y2="2.4892" width="0.1524" layer="51" curve="-180"/>
-<text x="-2.1844" y="1.143" size="1.27" layer="51" ratio="6" rot="SR0">*</text>
-<wire x1="-1.0922" y1="-2.6162" x2="1.0922" y2="-2.6162" width="0.1524" layer="21"/>
-<wire x1="1.0922" y1="2.6162" x2="-1.0922" y2="2.6162" width="0.1524" layer="21"/>
-<polygon width="0.0254" layer="21">
-<vertex x="4.1656" y="-1.397"/>
-<vertex x="4.1656" y="-1.778"/>
-<vertex x="3.9116" y="-1.778"/>
-<vertex x="3.9116" y="-1.397"/>
-</polygon>
-<text x="-3.3528" y="2.4892" size="1.27" layer="21" ratio="6" rot="SR0">*</text>
-<wire x1="-4.1656" y1="-2.9464" x2="-4.1656" y2="2.9464" width="0.1524" layer="39"/>
-<wire x1="-4.1656" y1="2.9464" x2="-2.4892" y2="2.9464" width="0.1524" layer="39"/>
-<wire x1="-2.4892" y1="2.9464" x2="-2.4892" y2="2.9972" width="0.1524" layer="39"/>
-<wire x1="-2.4892" y1="2.9972" x2="2.4892" y2="2.9972" width="0.1524" layer="39"/>
-<wire x1="2.4892" y1="2.9972" x2="2.4892" y2="2.9464" width="0.1524" layer="39"/>
-<wire x1="4.1656" y1="2.9464" x2="2.4892" y2="2.9464" width="0.1524" layer="39"/>
-<wire x1="4.1656" y1="2.9464" x2="4.1656" y2="-2.9464" width="0.1524" layer="39"/>
-<wire x1="4.1656" y1="-2.9464" x2="2.4892" y2="-2.9464" width="0.1524" layer="39"/>
-<wire x1="2.4892" y1="-2.9464" x2="2.4892" y2="-2.9972" width="0.1524" layer="39"/>
-<wire x1="2.4892" y1="-2.9972" x2="-2.4892" y2="-2.9972" width="0.1524" layer="39"/>
-<wire x1="-2.4892" y1="-2.9972" x2="-2.4892" y2="-2.9464" width="0.1524" layer="39"/>
-<wire x1="-4.1656" y1="-2.9464" x2="-2.4892" y2="-2.9464" width="0.1524" layer="39"/>
+<wire x1="0.3048" y1="2.5146" x2="-0.3048" y2="2.4892" width="0.1524" layer="51" curve="-180"/>
+<text x="-2.1844" y="1.1684" size="1.27" layer="51" ratio="6" rot="SR0">*</text>
+<wire x1="-3.7084" y1="-2.4384" x2="-3.7084" y2="2.4384" width="0.1524" layer="39"/>
+<wire x1="-3.7084" y1="2.4384" x2="-2.2352" y2="2.4384" width="0.1524" layer="39"/>
+<wire x1="-2.2352" y1="2.4384" x2="-2.2352" y2="2.7432" width="0.1524" layer="39"/>
+<wire x1="-2.2352" y1="2.7432" x2="2.2352" y2="2.7432" width="0.1524" layer="39"/>
+<wire x1="2.2352" y1="2.7432" x2="2.2352" y2="2.4384" width="0.1524" layer="39"/>
+<wire x1="3.7084" y1="2.4384" x2="2.2352" y2="2.4384" width="0.1524" layer="39"/>
+<wire x1="3.7084" y1="2.4384" x2="3.7084" y2="-2.4384" width="0.1524" layer="39"/>
+<wire x1="3.7084" y1="-2.4384" x2="2.2352" y2="-2.4384" width="0.1524" layer="39"/>
+<wire x1="2.2352" y1="-2.4384" x2="2.2352" y2="-2.7432" width="0.1524" layer="39"/>
+<wire x1="2.2352" y1="-2.7432" x2="-2.2352" y2="-2.7432" width="0.1524" layer="39"/>
+<wire x1="-2.2352" y1="-2.7432" x2="-2.2352" y2="-2.4384" width="0.1524" layer="39"/>
+<wire x1="-3.7084" y1="-2.4384" x2="-2.2352" y2="-2.4384" width="0.1524" layer="39"/>
 <polygon width="0.1524" layer="39">
-<vertex x="-4.1656" y="-2.9337"/>
-<vertex x="-4.1656" y="2.9337"/>
-<vertex x="-2.5019" y="2.9337"/>
-<vertex x="-2.5019" y="2.9972"/>
-<vertex x="2.5019" y="2.9972"/>
-<vertex x="2.5019" y="2.9337"/>
-<vertex x="4.1656" y="2.9337"/>
-<vertex x="4.1656" y="-2.9337"/>
-<vertex x="2.5019" y="-2.9337"/>
-<vertex x="2.5019" y="-2.9972"/>
-<vertex x="-2.5019" y="-2.9972"/>
-<vertex x="-2.5019" y="-2.9337"/>
+<vertex x="-3.7084" y="-2.4257"/>
+<vertex x="-3.7084" y="2.4257"/>
+<vertex x="-2.2479" y="2.4257"/>
+<vertex x="-2.2479" y="2.7559"/>
+<vertex x="2.2479" y="2.7559"/>
+<vertex x="2.2479" y="2.4257"/>
+<vertex x="3.7084" y="2.4257"/>
+<vertex x="3.7084" y="-2.4257"/>
+<vertex x="2.2479" y="-2.4257"/>
+<vertex x="2.2479" y="-2.7559"/>
+<vertex x="-2.2479" y="-2.7559"/>
+<vertex x="-2.2479" y="-2.4257"/>
 </polygon>
+<wire x1="-2.1336" y1="-2.6416" x2="2.1336" y2="-2.6416" width="0.1524" layer="21"/>
+<wire x1="2.1336" y1="2.6416" x2="-2.1336" y2="2.6416" width="0.1524" layer="21"/>
+<text x="-3.302" y="2.3114" size="1.27" layer="21" ratio="6" rot="SR0">*</text>
+<wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
+<wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
+<text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+</package>
+<package name="TEENSY_3.5_SIMPLE">
+<pad name="AGND" x="16.51" y="57.15" drill="0.8" shape="long"/>
+<pad name="D13" x="16.51" y="26.67" drill="0.8" shape="long"/>
+<pad name="A0" x="16.51" y="29.21" drill="0.8" shape="long"/>
+<pad name="A1" x="16.51" y="31.75" drill="0.8" shape="long"/>
+<pad name="A2" x="16.51" y="34.29" drill="0.8" shape="long"/>
+<pad name="A3" x="16.51" y="36.83" drill="0.8" shape="long"/>
+<pad name="A4" x="16.51" y="39.37" drill="0.8" shape="long"/>
+<pad name="A5" x="16.51" y="41.91" drill="0.8" shape="long"/>
+<pad name="A6" x="16.51" y="44.45" drill="0.8" shape="long"/>
+<pad name="A7" x="16.51" y="46.99" drill="0.8" shape="long"/>
+<pad name="A8" x="16.51" y="49.53" drill="0.8" shape="long"/>
+<pad name="D12" x="1.27" y="26.67" drill="0.8" shape="long"/>
+<pad name="D11" x="1.27" y="29.21" drill="0.8" shape="long"/>
+<pad name="D5" x="1.27" y="44.45" drill="0.8" shape="long"/>
+<pad name="D4(CANRX)" x="1.27" y="46.99" drill="0.8" shape="long"/>
+<pad name="D3(CANTX)" x="1.27" y="49.53" drill="0.8" shape="long"/>
+<pad name="D2" x="1.27" y="52.07" drill="0.8" shape="long"/>
+<pad name="GND" x="1.27" y="59.69" drill="0.8" shape="long"/>
+<pad name="VIN" x="16.51" y="59.69" drill="0.8" shape="long"/>
+<pad name="3.3V2" x="16.51" y="54.61" drill="0.8" shape="long"/>
+<pad name="A9" x="16.51" y="52.07" drill="0.8" shape="long"/>
+<pad name="D0(RX1)" x="1.27" y="57.15" drill="0.8" shape="long" rot="R180"/>
+<pad name="D1(TX1)" x="1.27" y="54.61" drill="0.8" shape="long" rot="R180"/>
+<pad name="D10(TX2)" x="1.27" y="31.75" drill="0.8" shape="long"/>
+<pad name="D6" x="1.27" y="41.91" drill="0.8" shape="long" rot="R180"/>
+<pad name="D7(RX3)" x="1.27" y="39.37" drill="0.8" shape="long" rot="R180"/>
+<pad name="D8(TX3)" x="1.27" y="36.83" drill="0.8" shape="long" rot="R180"/>
+<pad name="D9(RX2)" x="1.27" y="34.29" drill="0.8" shape="long" rot="R180"/>
+<wire x1="17.78" y1="60.96" x2="17.78" y2="0" width="0.127" layer="21"/>
+<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="61.722" x2="12.7" y2="61.722" width="0.127" layer="21"/>
+<wire x1="12.7" y1="61.722" x2="12.7" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="60.96" x2="5.08" y2="61.722" width="0.127" layer="21"/>
+<wire x1="0" y1="60.96" x2="5.08" y2="60.96" width="0.127" layer="21"/>
+<wire x1="12.7" y1="60.96" x2="17.78" y2="60.96" width="0.127" layer="21"/>
+<wire x1="5.08" y1="60.96" x2="5.08" y2="55.88" width="0.127" layer="21"/>
+<wire x1="5.08" y1="55.88" x2="12.7" y2="55.88" width="0.127" layer="21"/>
+<wire x1="12.7" y1="55.88" x2="12.7" y2="60.96" width="0.127" layer="21"/>
+<pad name="3.3V" x="1.27" y="24.13" drill="0.8" shape="long"/>
+<pad name="D24" x="1.27" y="21.59" drill="0.8" shape="long"/>
+<pad name="D25" x="1.27" y="19.05" drill="0.8" shape="long"/>
+<pad name="D26" x="1.27" y="16.51" drill="0.8" shape="long"/>
+<pad name="D27" x="1.27" y="13.97" drill="0.8" shape="long"/>
+<pad name="D28" x="1.27" y="11.43" drill="0.8" shape="long"/>
+<pad name="D29" x="1.27" y="8.89" drill="0.8" shape="long"/>
+<pad name="D30" x="1.27" y="6.35" drill="0.8" shape="long"/>
+<pad name="A12" x="1.27" y="3.81" drill="0.8" shape="long"/>
+<pad name="A13" x="1.27" y="1.27" drill="0.8" shape="long"/>
+<pad name="GND2" x="16.51" y="24.13" drill="0.8" shape="long"/>
+<pad name="A22" x="16.51" y="21.59" drill="0.8" shape="long"/>
+<pad name="A21" x="16.51" y="19.05" drill="0.8" shape="long"/>
+<pad name="A20" x="16.51" y="16.51" drill="0.8" shape="long"/>
+<pad name="A19" x="16.51" y="13.97" drill="0.8" shape="long"/>
+<pad name="A18" x="16.51" y="11.43" drill="0.8" shape="long"/>
+<pad name="A17" x="16.51" y="8.89" drill="0.8" shape="long"/>
+<pad name="A16" x="16.51" y="6.35" drill="0.8" shape="long"/>
+<pad name="A15" x="16.51" y="3.81" drill="0.8" shape="long"/>
+<pad name="A14" x="16.51" y="1.27" drill="0.8" shape="long"/>
+<text x="8.89" y="58.7375" size="2.54" layer="21" align="center">3.5</text>
+</package>
+<package name="21-0041B_8-L">
+<smd name="1" x="-2.413" y="1.905" dx="1.6764" dy="0.4826" layer="1"/>
+<smd name="2" x="-2.413" y="0.635" dx="1.6764" dy="0.4826" layer="1"/>
+<smd name="3" x="-2.413" y="-0.635" dx="1.6764" dy="0.4826" layer="1"/>
+<smd name="4" x="-2.413" y="-1.905" dx="1.6764" dy="0.4826" layer="1"/>
+<smd name="5" x="2.413" y="-1.905" dx="1.6764" dy="0.4826" layer="1"/>
+<smd name="6" x="2.413" y="-0.635" dx="1.6764" dy="0.4826" layer="1"/>
+<smd name="7" x="2.413" y="0.635" dx="1.6764" dy="0.4826" layer="1"/>
+<smd name="8" x="2.413" y="1.905" dx="1.6764" dy="0.4826" layer="1"/>
+<wire x1="-1.9812" y1="1.6764" x2="-2.0066" y2="2.1336" width="0.1524" layer="51"/>
+<wire x1="-2.0066" y1="2.1336" x2="-3.0988" y2="2.1336" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="2.1336" x2="-3.0988" y2="1.651" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="1.651" x2="-1.9812" y2="1.6764" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="0.4064" x2="-2.0066" y2="0.8636" width="0.1524" layer="51"/>
+<wire x1="-2.0066" y1="0.8636" x2="-3.0988" y2="0.8636" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="0.8636" x2="-3.0988" y2="0.381" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="0.381" x2="-1.9812" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-0.8636" x2="-1.9812" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-0.4064" x2="-3.0988" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-0.4064" x2="-3.0988" y2="-0.889" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-0.889" x2="-1.9812" y2="-0.8636" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-2.1336" x2="-1.9812" y2="-1.6764" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-1.6764" x2="-3.0988" y2="-1.6764" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-1.6764" x2="-3.0988" y2="-2.159" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-2.159" x2="-1.9812" y2="-2.1336" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-1.6764" x2="2.0066" y2="-2.1336" width="0.1524" layer="51"/>
+<wire x1="2.0066" y1="-2.1336" x2="3.0988" y2="-2.1336" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-2.1336" x2="3.0988" y2="-1.651" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-1.651" x2="1.9812" y2="-1.6764" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-0.4064" x2="1.9812" y2="-0.8636" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-0.8636" x2="3.0988" y2="-0.8636" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-0.8636" x2="3.0988" y2="-0.381" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-0.381" x2="1.9812" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="0.8636" x2="1.9812" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="0.4064" x2="3.0988" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="0.4064" x2="3.0988" y2="0.889" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="0.889" x2="1.9812" y2="0.8636" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="2.1336" x2="1.9812" y2="1.6764" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="1.6764" x2="3.0988" y2="1.6764" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="1.6764" x2="3.0988" y2="2.159" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="2.159" x2="1.9812" y2="2.1336" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-2.4892" x2="1.9812" y2="-2.4892" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-2.4892" x2="1.9812" y2="2.4892" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="2.4892" x2="-0.3048" y2="2.4892" width="0.1524" layer="51"/>
+<wire x1="-0.3048" y1="2.4892" x2="-1.9812" y2="2.4892" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="2.4892" x2="-1.9812" y2="-2.4892" width="0.1524" layer="51"/>
+<wire x1="0.3048" y1="2.5146" x2="-0.3048" y2="2.4892" width="0.1524" layer="51" curve="-180"/>
+<text x="-2.1844" y="1.1684" size="1.27" layer="51" ratio="6" rot="SR0">*</text>
+<wire x1="-3.3528" y1="-2.2352" x2="-3.3528" y2="2.2352" width="0.1524" layer="39"/>
+<wire x1="-3.3528" y1="2.2352" x2="-2.0828" y2="2.2352" width="0.1524" layer="39"/>
+<wire x1="-2.0828" y1="2.2352" x2="-2.0828" y2="2.5908" width="0.1524" layer="39"/>
+<wire x1="-2.0828" y1="2.5908" x2="2.0828" y2="2.5908" width="0.1524" layer="39"/>
+<wire x1="2.0828" y1="2.5908" x2="2.0828" y2="2.2352" width="0.1524" layer="39"/>
+<wire x1="3.3528" y1="2.2352" x2="2.0828" y2="2.2352" width="0.1524" layer="39"/>
+<wire x1="3.3528" y1="2.2352" x2="3.3528" y2="-2.2352" width="0.1524" layer="39"/>
+<wire x1="3.3528" y1="-2.2352" x2="2.0828" y2="-2.2352" width="0.1524" layer="39"/>
+<wire x1="2.0828" y1="-2.2352" x2="2.0828" y2="-2.5908" width="0.1524" layer="39"/>
+<wire x1="2.0828" y1="-2.5908" x2="-2.0828" y2="-2.5908" width="0.1524" layer="39"/>
+<wire x1="-2.0828" y1="-2.5908" x2="-2.0828" y2="-2.2352" width="0.1524" layer="39"/>
+<wire x1="-3.3528" y1="-2.2352" x2="-2.0828" y2="-2.2352" width="0.1524" layer="39"/>
+<polygon width="0.1524" layer="39">
+<vertex x="-3.3528" y="-2.2479"/>
+<vertex x="-3.3528" y="2.2479"/>
+<vertex x="-2.0955" y="2.2479"/>
+<vertex x="-2.0955" y="2.6035"/>
+<vertex x="2.0955" y="2.6035"/>
+<vertex x="2.0955" y="2.2479"/>
+<vertex x="3.3528" y="2.2479"/>
+<vertex x="3.3528" y="-2.2479"/>
+<vertex x="2.0955" y="-2.2479"/>
+<vertex x="2.0955" y="-2.6035"/>
+<vertex x="-2.0955" y="-2.6035"/>
+<vertex x="-2.0955" y="-2.2479"/>
+</polygon>
+<wire x1="-2.1336" y1="-2.6416" x2="2.1336" y2="-2.6416" width="0.1524" layer="21"/>
+<wire x1="2.1336" y1="2.6416" x2="-2.1336" y2="2.6416" width="0.1524" layer="21"/>
+<text x="-3.2512" y="2.2606" size="1.27" layer="21" ratio="6" rot="SR0">*</text>
 <wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
 <wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
 <text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
@@ -11280,94 +11327,260 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
 <text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
 </package>
-<package name="AUTOSPORT_12-35">
-<pad name="P$1" x="1.143" y="5.0038" drill="1"/>
-<pad name="P$2" x="3.2004" y="4.0132" drill="1"/>
-<pad name="P$3" x="4.6228" y="2.2352" drill="1"/>
-<pad name="P$4" x="5.1562" y="0" drill="1"/>
-<pad name="P$5" x="4.6228" y="-2.2352" drill="1"/>
-<pad name="P$6" x="3.2004" y="-4.0132" drill="1"/>
-<pad name="P$7" x="1.143" y="-5.0038" drill="1"/>
-<pad name="P$8" x="-1.143" y="-5.0038" drill="1"/>
-<pad name="P$9" x="-3.2004" y="-4.0132" drill="1"/>
-<pad name="P$10" x="-4.6228" y="-2.2352" drill="1"/>
-<pad name="P$11" x="-5.1562" y="0" drill="1"/>
-<pad name="P$12" x="-3.2004" y="4.0132" drill="1"/>
-<pad name="P$13" x="-1.143" y="5.0038" drill="1"/>
-<pad name="P$14" x="1.143" y="2.7178" drill="1"/>
-<pad name="P$15" x="2.9718" y="0.6604" drill="1"/>
-<pad name="P$16" x="2.3622" y="-1.905" drill="1"/>
-<pad name="P$17" x="-2.3622" y="-1.905" drill="1"/>
-<pad name="P$18" x="-2.9718" y="0.6604" drill="1"/>
-<pad name="P$19" x="-1.143" y="2.7178" drill="1"/>
-<pad name="P$20" x="0" y="-0.762" drill="1"/>
-<pad name="P$21" x="0" y="-3.048" drill="1"/>
-<pad name="P$22" x="-4.6228" y="2.2352" drill="1"/>
-<circle x="0" y="0" radius="8.725" width="0.127" layer="21"/>
-<hole x="-10.2884" y="-10.2884" drill="3.3"/>
-<hole x="10.2884" y="10.2884" drill="3.3"/>
-<circle x="-10.2884" y="-10.2884" radius="3" width="0.127" layer="40"/>
-<circle x="10.2884" y="10.2884" radius="3" width="0.127" layer="40"/>
-<circle x="0" y="0" radius="13" width="0.127" layer="21"/>
+<package name="21-0041B_8-M">
+<smd name="1" x="-2.5146" y="1.905" dx="2.286" dy="0.5842" layer="1"/>
+<smd name="2" x="-2.5146" y="0.635" dx="2.286" dy="0.5842" layer="1"/>
+<smd name="3" x="-2.5146" y="-0.635" dx="2.286" dy="0.5842" layer="1"/>
+<smd name="4" x="-2.5146" y="-1.905" dx="2.286" dy="0.5842" layer="1"/>
+<smd name="5" x="2.5146" y="-1.905" dx="2.286" dy="0.5842" layer="1"/>
+<smd name="6" x="2.5146" y="-0.635" dx="2.286" dy="0.5842" layer="1"/>
+<smd name="7" x="2.5146" y="0.635" dx="2.286" dy="0.5842" layer="1"/>
+<smd name="8" x="2.5146" y="1.905" dx="2.286" dy="0.5842" layer="1"/>
+<wire x1="-1.9812" y1="1.6764" x2="-2.0066" y2="2.1336" width="0.1524" layer="51"/>
+<wire x1="-2.0066" y1="2.1336" x2="-3.0988" y2="2.1336" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="2.1336" x2="-3.0988" y2="1.651" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="1.651" x2="-1.9812" y2="1.6764" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="0.4064" x2="-2.0066" y2="0.8636" width="0.1524" layer="51"/>
+<wire x1="-2.0066" y1="0.8636" x2="-3.0988" y2="0.8636" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="0.8636" x2="-3.0988" y2="0.381" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="0.381" x2="-1.9812" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-0.8636" x2="-1.9812" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-0.4064" x2="-3.0988" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-0.4064" x2="-3.0988" y2="-0.889" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-0.889" x2="-1.9812" y2="-0.8636" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-2.1336" x2="-1.9812" y2="-1.6764" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-1.6764" x2="-3.0988" y2="-1.6764" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-1.6764" x2="-3.0988" y2="-2.159" width="0.1524" layer="51"/>
+<wire x1="-3.0988" y1="-2.159" x2="-1.9812" y2="-2.1336" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-1.6764" x2="2.0066" y2="-2.1336" width="0.1524" layer="51"/>
+<wire x1="2.0066" y1="-2.1336" x2="3.0988" y2="-2.1336" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-2.1336" x2="3.0988" y2="-1.651" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-1.651" x2="1.9812" y2="-1.6764" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-0.4064" x2="1.9812" y2="-0.8636" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-0.8636" x2="3.0988" y2="-0.8636" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-0.8636" x2="3.0988" y2="-0.381" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="-0.381" x2="1.9812" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="0.8636" x2="1.9812" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="0.4064" x2="3.0988" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="0.4064" x2="3.0988" y2="0.889" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="0.889" x2="1.9812" y2="0.8636" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="2.1336" x2="1.9812" y2="1.6764" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="1.6764" x2="3.0988" y2="1.6764" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="1.6764" x2="3.0988" y2="2.159" width="0.1524" layer="51"/>
+<wire x1="3.0988" y1="2.159" x2="1.9812" y2="2.1336" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="-2.4892" x2="1.9812" y2="-2.4892" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="-2.4892" x2="1.9812" y2="2.4892" width="0.1524" layer="51"/>
+<wire x1="1.9812" y1="2.4892" x2="-0.3048" y2="2.4892" width="0.1524" layer="51"/>
+<wire x1="-0.3048" y1="2.4892" x2="-1.9812" y2="2.4892" width="0.1524" layer="51"/>
+<wire x1="-1.9812" y1="2.4892" x2="-1.9812" y2="-2.4892" width="0.1524" layer="51"/>
+<wire x1="0.3048" y1="2.5146" x2="-0.3048" y2="2.4892" width="0.1524" layer="51" curve="-180"/>
+<text x="-2.1844" y="1.1684" size="1.27" layer="51" ratio="6" rot="SR0">*</text>
+<wire x1="-4.1656" y1="-2.6924" x2="-4.1656" y2="2.6924" width="0.1524" layer="39"/>
+<wire x1="-4.1656" y1="2.6924" x2="-2.4892" y2="2.6924" width="0.1524" layer="39"/>
+<wire x1="-2.4892" y1="2.6924" x2="-2.4892" y2="2.9972" width="0.1524" layer="39"/>
+<wire x1="-2.4892" y1="2.9972" x2="2.4892" y2="2.9972" width="0.1524" layer="39"/>
+<wire x1="2.4892" y1="2.9972" x2="2.4892" y2="2.6924" width="0.1524" layer="39"/>
+<wire x1="4.1656" y1="2.6924" x2="2.4892" y2="2.6924" width="0.1524" layer="39"/>
+<wire x1="4.1656" y1="2.6924" x2="4.1656" y2="-2.6924" width="0.1524" layer="39"/>
+<wire x1="4.1656" y1="-2.6924" x2="2.4892" y2="-2.6924" width="0.1524" layer="39"/>
+<wire x1="2.4892" y1="-2.6924" x2="2.4892" y2="-2.9972" width="0.1524" layer="39"/>
+<wire x1="2.4892" y1="-2.9972" x2="-2.4892" y2="-2.9972" width="0.1524" layer="39"/>
+<wire x1="-2.4892" y1="-2.9972" x2="-2.4892" y2="-2.6924" width="0.1524" layer="39"/>
+<wire x1="-4.1656" y1="-2.6924" x2="-2.4892" y2="-2.6924" width="0.1524" layer="39"/>
+<polygon width="0.1524" layer="39">
+<vertex x="-4.1656" y="-2.7051"/>
+<vertex x="-4.1656" y="2.7051"/>
+<vertex x="-2.5019" y="2.7051"/>
+<vertex x="-2.5019" y="3.0099"/>
+<vertex x="2.5019" y="3.0099"/>
+<vertex x="2.5019" y="2.7051"/>
+<vertex x="4.1656" y="2.7051"/>
+<vertex x="4.1656" y="-2.7051"/>
+<vertex x="2.5019" y="-2.7051"/>
+<vertex x="2.5019" y="-3.0099"/>
+<vertex x="-2.5019" y="-3.0099"/>
+<vertex x="-2.5019" y="-2.7051"/>
+</polygon>
+<wire x1="-2.1336" y1="-2.6416" x2="2.1336" y2="-2.6416" width="0.1524" layer="21"/>
+<wire x1="2.1336" y1="2.6416" x2="-2.1336" y2="2.6416" width="0.1524" layer="21"/>
+<text x="-3.3528" y="2.3622" size="1.27" layer="21" ratio="6" rot="SR0">*</text>
+<wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
+<wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
+<text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
 </package>
-<package name="AMPHENOL_10118192-0001LF">
-<wire x1="-3.75" y1="0.225" x2="3.75" y2="0.225" width="0.127" layer="51"/>
-<wire x1="3.75" y1="0.225" x2="3.75" y2="-4.125" width="0.127" layer="51"/>
-<wire x1="3.75" y1="-4.125" x2="3.75" y2="-5.436" width="0.127" layer="51"/>
-<wire x1="3.75" y1="-5.436" x2="-3.75" y2="-5.436" width="0.127" layer="51"/>
-<wire x1="-3.75" y1="-5.436" x2="-3.75" y2="-4.125" width="0.127" layer="51"/>
-<wire x1="-3.75" y1="-4.125" x2="-3.75" y2="0.225" width="0.127" layer="51"/>
-<wire x1="3.75" y1="-4.125" x2="-3.75" y2="-4.125" width="0.127" layer="51"/>
-<wire x1="3.75" y1="-4.125" x2="7.15" y2="-4.125" width="0.127" layer="51"/>
-<text x="5.204959375" y="-3.90371875" size="0.813575" layer="51">PCB Edge</text>
-<wire x1="-3.75" y1="-1.15" x2="-3.75" y2="-1.5" width="0.127" layer="21"/>
-<wire x1="3.75" y1="-1.15" x2="3.75" y2="-1.5" width="0.127" layer="21"/>
-<wire x1="-3.75" y1="-3.85" x2="-3.75" y2="-4.125" width="0.127" layer="21"/>
-<wire x1="-3.75" y1="-4.125" x2="3.75" y2="-4.125" width="0.127" layer="21"/>
-<wire x1="3.75" y1="-4.125" x2="3.75" y2="-3.85" width="0.127" layer="21"/>
-<wire x1="-1.83" y1="0.225" x2="-1.72" y2="0.225" width="0.127" layer="21"/>
-<wire x1="1.72" y1="0.225" x2="1.83" y2="0.225" width="0.127" layer="21"/>
-<wire x1="-4.95" y1="0.925" x2="4.95" y2="0.925" width="0.05" layer="39"/>
-<wire x1="4.95" y1="0.925" x2="4.95" y2="-5.686" width="0.05" layer="39"/>
-<wire x1="4.95" y1="-5.686" x2="-4.95" y2="-5.686" width="0.05" layer="39"/>
-<wire x1="-4.95" y1="-5.686" x2="-4.95" y2="0.925" width="0.05" layer="39"/>
-<circle x="-1.4" y="1.3" radius="0.1" width="0.3" layer="21"/>
-<circle x="-1.4" y="1.3" radius="0.1" width="0.3" layer="51"/>
-<text x="-4.953109375" y="1.778040625" size="1.00001875" layer="25">&gt;NAME</text>
-<text x="-5.080290625" y="-6.350359375" size="1.000059375" layer="27">&gt;VALUE</text>
-<smd name="3" x="0" y="0" dx="0.4" dy="1.35" layer="1"/>
-<smd name="2" x="-0.65" y="0" dx="0.4" dy="1.35" layer="1"/>
-<smd name="4" x="0.65" y="0" dx="0.4" dy="1.35" layer="1"/>
-<smd name="1" x="-1.3" y="0" dx="0.4" dy="1.35" layer="1"/>
-<smd name="5" x="1.3" y="0" dx="0.4" dy="1.35" layer="1"/>
-<smd name="SH1" x="-3.1" y="-0.125" dx="2.1" dy="1.6" layer="1"/>
-<smd name="SH2" x="3.1" y="-0.125" dx="2.1" dy="1.6" layer="1"/>
-<smd name="SH3" x="-3.8" y="-2.675" dx="1.8" dy="1.9" layer="1" rot="R180"/>
-<smd name="SH6" x="3.8" y="-2.675" dx="1.8" dy="1.9" layer="1" rot="R180"/>
-<smd name="SH4" x="-1.2" y="-2.675" dx="1.9" dy="1.9" layer="1"/>
-<smd name="SH5" x="1.2" y="-2.675" dx="1.9" dy="1.9" layer="1"/>
+<package name="TEENSY_4.0_EXT">
+<pad name="GND3" x="16.51" y="31.75" drill="0.8" shape="long"/>
+<pad name="D13" x="16.51" y="1.27" drill="0.8" shape="long"/>
+<pad name="(TX3)A0" x="16.51" y="3.81" drill="0.8" shape="long"/>
+<pad name="(RX3)A1" x="16.51" y="6.35" drill="0.8" shape="long"/>
+<pad name="A2" x="16.51" y="8.89" drill="0.8" shape="long"/>
+<pad name="A3" x="16.51" y="11.43" drill="0.8" shape="long"/>
+<pad name="A4" x="16.51" y="13.97" drill="0.8" shape="long"/>
+<pad name="A5" x="16.51" y="16.51" drill="0.8" shape="long"/>
+<pad name="A6" x="16.51" y="19.05" drill="0.8" shape="long"/>
+<pad name="A7" x="16.51" y="21.59" drill="0.8" shape="long"/>
+<pad name="(CANTX)A8" x="16.51" y="24.13" drill="0.8" shape="long"/>
+<pad name="D12" x="1.27" y="1.27" drill="0.8" shape="long"/>
+<pad name="D11" x="1.27" y="3.81" drill="0.8" shape="long"/>
+<pad name="D5" x="1.27" y="19.05" drill="0.8" shape="long"/>
+<pad name="D4" x="1.27" y="21.59" drill="0.8" shape="long"/>
+<pad name="D3" x="1.27" y="24.13" drill="0.8" shape="long"/>
+<pad name="D2" x="1.27" y="26.67" drill="0.8" shape="long"/>
+<pad name="GND" x="1.27" y="34.29" drill="0.8" shape="long"/>
+<pad name="VIN" x="16.51" y="34.29" drill="0.8" shape="long"/>
+<pad name="3.3V2" x="16.51" y="29.21" drill="0.8" shape="long"/>
+<pad name="(CANRX)A9" x="16.51" y="26.67" drill="0.8" shape="long"/>
+<pad name="D0(RX1)" x="1.27" y="31.75" drill="0.8" shape="long" rot="R180"/>
+<pad name="D1(TX1)" x="1.27" y="29.21" drill="0.8" shape="long" rot="R180"/>
+<pad name="D10" x="1.27" y="6.35" drill="0.8" shape="long"/>
+<pad name="D6" x="1.27" y="16.51" drill="0.8" shape="long" rot="R180"/>
+<pad name="D7(RX2)" x="1.27" y="13.97" drill="0.8" shape="long" rot="R180"/>
+<pad name="D8(TX2)" x="1.27" y="11.43" drill="0.8" shape="long" rot="R180"/>
+<pad name="D9" x="1.27" y="8.89" drill="0.8" shape="long" rot="R180"/>
+<wire x1="17.78" y1="35.56" x2="17.78" y2="0" width="0.127" layer="21"/>
+<wire x1="17.78" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="36.322" x2="12.7" y2="36.322" width="0.127" layer="21"/>
+<wire x1="12.7" y1="36.322" x2="12.7" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="35.56" x2="5.08" y2="36.322" width="0.127" layer="21"/>
+<wire x1="0" y1="35.56" x2="5.08" y2="35.56" width="0.127" layer="21"/>
+<wire x1="12.7" y1="35.56" x2="17.78" y2="35.56" width="0.127" layer="21"/>
+<wire x1="5.08" y1="35.56" x2="5.08" y2="30.48" width="0.127" layer="21"/>
+<wire x1="5.08" y1="30.48" x2="12.7" y2="30.48" width="0.127" layer="21"/>
+<wire x1="12.7" y1="30.48" x2="12.7" y2="35.56" width="0.127" layer="21"/>
+<pad name="VBAT" x="3.81" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<pad name="3.3V" x="6.35" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<pad name="GND2" x="8.89" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<pad name="PGRM" x="11.43" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<pad name="ON/OFF" x="13.97" y="1.27" drill="0.8" shape="long" rot="R90"/>
+<text x="8.89" y="33.3375" size="2.54" layer="21" align="center">4.0</text>
 </package>
-<package name="XP-E2">
-<description>&lt;b&gt;Cree® XLamp® XP-E2 LEDs&lt;/b&gt;&lt;p&gt;
-&lt;a href="https://www.cree.com/led-components/media/documents/XLampXPE2.pdf"&gt;Source: www.cree.com/xlamp .. XLampXP-E2.pdf&lt;/a&gt;</description>
-<circle x="-2.0574" y="-2.0574" radius="0.1524" width="0" layer="51"/>
-<circle x="0" y="0" radius="1.25" width="0.2032" layer="51"/>
-<wire x1="-1.778" y1="1.778" x2="1.778" y2="1.778" width="0.2032" layer="51"/>
-<wire x1="1.778" y1="1.778" x2="1.778" y2="-1.778" width="0.2032" layer="51"/>
-<wire x1="1.778" y1="-1.778" x2="-1.778" y2="-1.778" width="0.2032" layer="51"/>
-<wire x1="-1.778" y1="-1.778" x2="-1.778" y2="1.778" width="0.2032" layer="51"/>
-<wire x1="-1.525" y1="0" x2="-1.15" y2="0" width="0.1016" layer="51"/>
-<wire x1="-1.325" y1="0.175" x2="-1.325" y2="-0.175" width="0.1016" layer="51"/>
-<rectangle x1="-0.5005" y1="-0.375" x2="0.5005" y2="0.375" layer="31"/>
-<rectangle x1="-1.65" y1="-1.65" x2="-1.15" y2="1.65" layer="31"/>
-<rectangle x1="1.15" y1="-1.65" x2="1.65" y2="1.65" layer="31"/>
-<rectangle x1="-0.5005" y1="0.625" x2="0.5005" y2="1.375" layer="31"/>
-<rectangle x1="-0.5005" y1="-1.375" x2="0.5005" y2="-0.625" layer="31"/>
-<smd name="A" x="-1.4" y="0" dx="0.5" dy="3.3" layer="1" cream="no"/>
-<smd name="C" x="1.4" y="0" dx="0.5" dy="3.3" layer="1" cream="no"/>
-<smd name="X" x="0" y="0" dx="1.3" dy="3.3" layer="1" cream="no"/>
-<text x="-2.54" y="-3.81" size="1.27" layer="25" font="vector">&gt;NAME</text>
-<text x="-2.54" y="2.54" size="1.27" layer="27" font="vector">&gt;VALUE</text>
+<package name="MSOP-8_MS">
+<smd name="1" x="-2.2098" y="0.975" dx="1.397" dy="0.4318" layer="1"/>
+<smd name="2" x="-2.2098" y="0.325" dx="1.397" dy="0.4318" layer="1"/>
+<smd name="3" x="-2.2098" y="-0.325" dx="1.397" dy="0.4318" layer="1"/>
+<smd name="4" x="-2.2098" y="-0.975" dx="1.397" dy="0.4318" layer="1"/>
+<smd name="5" x="2.2098" y="-0.975" dx="1.397" dy="0.4318" layer="1"/>
+<smd name="6" x="2.2098" y="-0.325" dx="1.397" dy="0.4318" layer="1"/>
+<smd name="7" x="2.2098" y="0.325" dx="1.397" dy="0.4318" layer="1"/>
+<smd name="8" x="2.2098" y="0.975" dx="1.397" dy="0.4318" layer="1"/>
+<wire x1="-1.5494" y1="0.7874" x2="-1.5494" y2="1.1684" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="1.1684" x2="-2.54" y2="1.1684" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="1.1684" x2="-2.54" y2="0.7874" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="0.7874" x2="-1.5494" y2="0.7874" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="0.127" x2="-1.5494" y2="0.508" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="0.508" x2="-2.54" y2="0.508" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="0.508" x2="-2.54" y2="0.127" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="0.127" x2="-1.5494" y2="0.127" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="-0.508" x2="-1.5494" y2="-0.127" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="-0.127" x2="-2.54" y2="-0.127" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="-0.127" x2="-2.54" y2="-0.508" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="-0.508" x2="-1.5494" y2="-0.508" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="-1.1684" x2="-1.5494" y2="-0.7874" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="-0.7874" x2="-2.54" y2="-0.7874" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="-0.7874" x2="-2.54" y2="-1.1684" width="0.1524" layer="51"/>
+<wire x1="-2.54" y1="-1.1684" x2="-1.5494" y2="-1.1684" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="-0.7874" x2="1.5494" y2="-1.1684" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="-1.1684" x2="2.54" y2="-1.1684" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="-1.1684" x2="2.54" y2="-0.7874" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="-0.7874" x2="1.5494" y2="-0.7874" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="-0.127" x2="1.5494" y2="-0.508" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="-0.508" x2="2.54" y2="-0.508" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="-0.508" x2="2.54" y2="-0.127" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="-0.127" x2="1.5494" y2="-0.127" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="0.508" x2="1.5494" y2="0.127" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="0.127" x2="2.54" y2="0.127" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="0.127" x2="2.54" y2="0.508" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="0.508" x2="1.5494" y2="0.508" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="1.1684" x2="1.5494" y2="0.7874" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="0.7874" x2="2.54" y2="0.7874" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="0.7874" x2="2.54" y2="1.1684" width="0.1524" layer="51"/>
+<wire x1="2.54" y1="1.1684" x2="1.5494" y2="1.1684" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="-1.5494" x2="1.5494" y2="-1.5494" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="-1.5494" x2="1.5494" y2="1.5494" width="0.1524" layer="51"/>
+<wire x1="1.5494" y1="1.5494" x2="0.3048" y2="1.5494" width="0.1524" layer="51"/>
+<wire x1="0.3048" y1="1.5494" x2="-0.3048" y2="1.5494" width="0.1524" layer="51"/>
+<wire x1="-0.3048" y1="1.5494" x2="-1.5494" y2="1.5494" width="0.1524" layer="51"/>
+<wire x1="-1.5494" y1="1.5494" x2="-1.5494" y2="-1.5494" width="0.1524" layer="51"/>
+<wire x1="0.3048" y1="1.5494" x2="-0.3048" y2="1.5494" width="0.1524" layer="51" curve="-180"/>
+<text x="-1.7526" y="0.2032" size="1.27" layer="51" ratio="6" rot="SR0">*</text>
+<wire x1="-3.1496" y1="-1.4478" x2="-3.1496" y2="1.4478" width="0.1524" layer="39"/>
+<wire x1="-3.1496" y1="1.4478" x2="-1.8034" y2="1.4478" width="0.1524" layer="39"/>
+<wire x1="-1.8034" y1="1.4478" x2="-1.8034" y2="1.8034" width="0.1524" layer="39"/>
+<wire x1="-1.8034" y1="1.8034" x2="1.8034" y2="1.8034" width="0.1524" layer="39"/>
+<wire x1="1.8034" y1="1.8034" x2="1.8034" y2="1.4478" width="0.1524" layer="39"/>
+<wire x1="3.1496" y1="1.4478" x2="1.8034" y2="1.4478" width="0.1524" layer="39"/>
+<wire x1="3.1496" y1="1.4478" x2="3.1496" y2="-1.4478" width="0.1524" layer="39"/>
+<wire x1="3.1496" y1="-1.4478" x2="1.8034" y2="-1.4478" width="0.1524" layer="39"/>
+<wire x1="1.8034" y1="-1.4478" x2="1.8034" y2="-1.8034" width="0.1524" layer="39"/>
+<wire x1="1.8034" y1="-1.8034" x2="-1.8034" y2="-1.8034" width="0.1524" layer="39"/>
+<wire x1="-1.8034" y1="-1.8034" x2="-1.8034" y2="-1.4478" width="0.1524" layer="39"/>
+<wire x1="-3.1496" y1="-1.4478" x2="-1.8034" y2="-1.4478" width="0.1524" layer="39"/>
+<polygon width="0.1524" layer="39">
+<vertex x="-3.1623" y="-1.4449"/>
+<vertex x="-3.1623" y="1.4449"/>
+<vertex x="-1.8034" y="1.4449"/>
+<vertex x="-1.8034" y="1.8034"/>
+<vertex x="1.8034" y="1.8034"/>
+<vertex x="1.8034" y="1.4449"/>
+<vertex x="3.1623" y="1.4449"/>
+<vertex x="3.1623" y="-1.4449"/>
+<vertex x="1.8034" y="-1.4449"/>
+<vertex x="1.8034" y="-1.8034"/>
+<vertex x="-1.8034" y="-1.8034"/>
+<vertex x="-1.8034" y="-1.4449"/>
+</polygon>
+<wire x1="-1.6764" y1="-1.6764" x2="1.6764" y2="-1.6764" width="0.1524" layer="21"/>
+<wire x1="1.6764" y1="-1.6764" x2="1.6764" y2="-1.524" width="0.1524" layer="21"/>
+<wire x1="1.6764" y1="1.6764" x2="-1.6764" y2="1.6764" width="0.1524" layer="21"/>
+<wire x1="-1.6764" y1="1.6764" x2="-1.6764" y2="1.524" width="0.1524" layer="21"/>
+<wire x1="-1.6764" y1="-1.524" x2="-1.6764" y2="-1.6764" width="0.1524" layer="21"/>
+<wire x1="1.6764" y1="1.524" x2="1.6764" y2="1.6764" width="0.1524" layer="21"/>
+<text x="-3.048" y="1.27" size="1.27" layer="21" ratio="6" rot="SR0">*</text>
+<wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
+<wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
+<text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+</package>
+<package name="PCC-SMP">
+<description>&lt;b&gt;PCC-SMP&lt;/b&gt;&lt;br&gt;
+</description>
+<pad name="1" x="2.25" y="6.85" drill="1.77" diameter="2.7"/>
+<pad name="2" x="2.25" y="-6.85" drill="1.77" diameter="2.7"/>
+<pad name="3" x="15.75" y="7.85" drill="1.77" diameter="2.7"/>
+<pad name="4" x="15.75" y="-7.85" drill="1.77" diameter="2.7"/>
+<text x="7.85763125" y="0.02243125" size="1.27" layer="25" align="center">&gt;NAME</text>
+<text x="7.85763125" y="0.02243125" size="1.27" layer="27" align="center">&gt;VALUE</text>
+<wire x1="0" y1="7.75" x2="20.8" y2="7.75" width="0.2" layer="51"/>
+<wire x1="20.8" y1="7.75" x2="20.8" y2="-7.75" width="0.2" layer="51"/>
+<wire x1="20.8" y1="-7.75" x2="0" y2="-7.75" width="0.2" layer="51"/>
+<wire x1="0" y1="-7.75" x2="0" y2="7.75" width="0.2" layer="51"/>
+<wire x1="0" y1="7.75" x2="0" y2="-7.75" width="0.2" layer="21"/>
+<wire x1="20.8" y1="-7.75" x2="20.8" y2="7.75" width="0.2" layer="21"/>
+<wire x1="20.8" y1="7.75" x2="17.4" y2="7.75" width="0.2" layer="21"/>
+<wire x1="3.517" y1="7.75" x2="14.1" y2="7.75" width="0.2" layer="21"/>
+<wire x1="3.517" y1="-7.75" x2="14.1" y2="-7.75" width="0.2" layer="21"/>
+<wire x1="20.8" y1="-7.75" x2="17.4" y2="-7.75" width="0.2" layer="21"/>
+<circle x="-0.721" y="6.932" radius="0.111" width="0.2" layer="25"/>
+</package>
+<package name="5X20MM_FUSE">
+<smd name="P$1" x="-7.493" y="0" dx="5.08" dy="5.588" layer="1" rot="R90"/>
+<smd name="P$2" x="7.493" y="0" dx="5.08" dy="5.588" layer="1" rot="R90"/>
+<wire x1="-10.414" y1="2.667" x2="10.414" y2="2.667" width="0.127" layer="21"/>
+<wire x1="10.414" y1="2.667" x2="10.414" y2="-2.667" width="0.127" layer="21"/>
+<wire x1="10.414" y1="-2.667" x2="-10.414" y2="-2.667" width="0.127" layer="21"/>
+<wire x1="-10.414" y1="-2.667" x2="-10.414" y2="2.667" width="0.127" layer="21"/>
+</package>
+<package name="PWR163">
+<smd name="PAD" x="0" y="0" dx="7.874" dy="8.509" layer="1"/>
+<smd name="1" x="-2.54" y="-7.366" dx="2.54" dy="1.143" layer="1" rot="R90"/>
+<smd name="2" x="2.54" y="-7.366" dx="2.54" dy="1.143" layer="1" rot="R90"/>
+<wire x1="-4.064" y1="4.3815" x2="4.064" y2="4.3815" width="0.127" layer="21"/>
+<wire x1="4.064" y1="4.3815" x2="4.064" y2="-4.3815" width="0.127" layer="21"/>
+<wire x1="4.064" y1="-4.3815" x2="-4.064" y2="-4.3815" width="0.127" layer="21"/>
+<wire x1="-4.064" y1="-4.3815" x2="-4.064" y2="4.3815" width="0.127" layer="21"/>
+</package>
+<package name="KEYSTONE5222">
+<smd name="P$1" x="0" y="0" dx="11.303" dy="13.208" layer="1"/>
 </package>
 </packages>
 <symbols>
@@ -12457,7 +12670,7 @@ DC/DC</text>
 <wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
 <wire x1="20.32" y1="0" x2="20.32" y2="40.64" width="0.254" layer="94"/>
 <wire x1="20.32" y1="40.64" x2="0" y2="40.64" width="0.254" layer="94"/>
-<text x="10.31875" y="1.27" size="1.778" layer="95" align="bottom-center">Teensy 3.2</text>
+<text x="5.08" y="1.27" size="1.778" layer="95">Teensy 3.2</text>
 <pin name="D2" x="-2.54" y="30.48" visible="pin" length="short"/>
 <pin name="D3(CANTX)" x="-2.54" y="27.94" visible="pin" length="short"/>
 <pin name="D4(CANRX)" x="-2.54" y="25.4" visible="pin" length="short"/>
@@ -12554,60 +12767,6 @@ DC/DC</text>
 <pin name="C2" x="20.32" y="-7.62" visible="pin" length="short" direction="pas" rot="R180"/>
 <pin name="EM1" x="20.32" y="-5.08" visible="pin" length="short" direction="pas" rot="R180"/>
 <pin name="C1" x="20.32" y="-2.54" visible="pin" length="short" direction="pas" rot="R180"/>
-</symbol>
-<symbol name="LTC6804-1">
-<wire x1="20.32" y1="0" x2="20.32" y2="-63.5" width="0.254" layer="94"/>
-<wire x1="20.32" y1="-63.5" x2="0" y2="-63.5" width="0.254" layer="94"/>
-<wire x1="0" y1="-63.5" x2="0" y2="0" width="0.254" layer="94"/>
-<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
-<pin name="IPB" x="22.86" y="-2.54" length="short" rot="R180"/>
-<pin name="IMB" x="22.86" y="-5.08" length="short" rot="R180"/>
-<pin name="ICMP" x="22.86" y="-7.62" length="short" rot="R180"/>
-<pin name="IBIAS" x="22.86" y="-10.16" length="short" rot="R180"/>
-<pin name="SDO(NC)" x="22.86" y="-12.7" length="short" rot="R180"/>
-<pin name="SDI(NC)" x="22.86" y="-15.24" length="short" rot="R180"/>
-<pin name="SCK(IPA)" x="22.86" y="-17.78" length="short" rot="R180"/>
-<pin name="CSB(IMA)" x="22.86" y="-20.32" length="short" rot="R180"/>
-<pin name="ISOMD" x="22.86" y="-22.86" length="short" rot="R180"/>
-<pin name="WDT" x="22.86" y="-25.4" length="short" rot="R180"/>
-<pin name="DRIVE" x="22.86" y="-27.94" length="short" rot="R180"/>
-<pin name="VREG" x="22.86" y="-30.48" length="short" rot="R180"/>
-<pin name="SWTEN" x="22.86" y="-33.02" length="short" rot="R180"/>
-<pin name="VREF1" x="22.86" y="-35.56" length="short" rot="R180"/>
-<pin name="VREF2" x="22.86" y="-38.1" length="short" rot="R180"/>
-<pin name="GPI05" x="22.86" y="-40.64" length="short" rot="R180"/>
-<pin name="GPI04" x="22.86" y="-43.18" length="short" rot="R180"/>
-<pin name="V-" x="22.86" y="-45.72" length="short" rot="R180"/>
-<pin name="V-**" x="22.86" y="-48.26" length="short" rot="R180"/>
-<pin name="GPI03" x="22.86" y="-50.8" length="short" rot="R180"/>
-<pin name="GPI02" x="22.86" y="-53.34" length="short" rot="R180"/>
-<pin name="GPI01" x="22.86" y="-55.88" length="short" rot="R180"/>
-<pin name="C0" x="22.86" y="-58.42" length="short" rot="R180"/>
-<pin name="S1" x="22.86" y="-60.96" length="short" rot="R180"/>
-<pin name="C1" x="-2.54" y="-60.96" length="short"/>
-<pin name="S2" x="-2.54" y="-58.42" length="short"/>
-<pin name="C2" x="-2.54" y="-55.88" length="short"/>
-<pin name="S3" x="-2.54" y="-53.34" length="short"/>
-<pin name="C3" x="-2.54" y="-50.8" length="short"/>
-<pin name="S4" x="-2.54" y="-48.26" length="short"/>
-<pin name="C4" x="-2.54" y="-45.72" length="short"/>
-<pin name="S5" x="-2.54" y="-43.18" length="short"/>
-<pin name="C5" x="-2.54" y="-40.64" length="short"/>
-<pin name="S6" x="-2.54" y="-38.1" length="short"/>
-<pin name="C6" x="-2.54" y="-35.56" length="short"/>
-<pin name="S7" x="-2.54" y="-33.02" length="short"/>
-<pin name="C7" x="-2.54" y="-30.48" length="short"/>
-<pin name="S8" x="-2.54" y="-27.94" length="short"/>
-<pin name="C8" x="-2.54" y="-25.4" length="short"/>
-<pin name="S9" x="-2.54" y="-22.86" length="short"/>
-<pin name="C9" x="-2.54" y="-20.32" length="short"/>
-<pin name="S10" x="-2.54" y="-17.78" length="short"/>
-<pin name="C10" x="-2.54" y="-15.24" length="short"/>
-<pin name="S11" x="-2.54" y="-12.7" length="short"/>
-<pin name="C11" x="-2.54" y="-10.16" length="short"/>
-<pin name="S12" x="-2.54" y="-7.62" length="short"/>
-<pin name="C12" x="-2.54" y="-5.08" length="short"/>
-<pin name="V+" x="-2.54" y="-2.54" length="short"/>
 </symbol>
 <symbol name="TRANSFORMER">
 <wire x1="-2.5654" y1="0" x2="-3.8354" y2="-1.27" width="0.254" layer="94" curve="90" cap="flat"/>
@@ -13348,7 +13507,7 @@ DC/DC</text>
 <wire x1="20.32" y1="-2.54" x2="-2.54" y2="-2.54" width="0.254" layer="94"/>
 <wire x1="-2.54" y1="-2.54" x2="-2.54" y2="7.62" width="0.254" layer="94"/>
 </symbol>
-<symbol name="TEENSY_3.5_EXT_RTC">
+<symbol name="TEENSY_3.5_SIMPLE_RTC">
 <pin name="D0(RX1)" x="-2.54" y="66.04" visible="pin" length="short"/>
 <pin name="D1(TX1)" x="-2.54" y="63.5" visible="pin" length="short"/>
 <pin name="GND" x="-2.54" y="68.58" visible="pin" length="short"/>
@@ -13356,7 +13515,7 @@ DC/DC</text>
 <wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
 <wire x1="20.32" y1="0" x2="20.32" y2="73.66" width="0.254" layer="94"/>
 <wire x1="20.32" y1="73.66" x2="0" y2="73.66" width="0.254" layer="94"/>
-<text x="10.31875" y="70.866" size="1.778" layer="95" align="bottom-center">Teensy 3.5</text>
+<text x="5.08" y="70.866" size="1.778" layer="95">Teensy 3.5</text>
 <pin name="D2" x="-2.54" y="60.96" visible="pin" length="short"/>
 <pin name="D3(CANTX)" x="-2.54" y="58.42" visible="pin" length="short"/>
 <pin name="D4(CANRX)" x="-2.54" y="55.88" visible="pin" length="short"/>
@@ -13379,10 +13538,10 @@ DC/DC</text>
 <pin name="A7" x="22.86" y="55.88" visible="pin" length="short" rot="R180"/>
 <pin name="A9" x="22.86" y="60.96" visible="pin" length="short" rot="R180"/>
 <pin name="A8" x="22.86" y="58.42" visible="pin" length="short" rot="R180"/>
-<pin name="3.3V3" x="22.86" y="63.5" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V" x="22.86" y="63.5" visible="pin" length="short" rot="R180"/>
 <pin name="VIN" x="22.86" y="68.58" visible="pin" length="short" rot="R180"/>
 <pin name="AGND" x="22.86" y="66.04" visible="pin" length="short" rot="R180"/>
-<pin name="3.3V" x="-2.54" y="33.02" visible="pin" length="short"/>
+<pin name="3.3V_1" x="-2.54" y="33.02" visible="pin" length="short"/>
 <pin name="D24" x="-2.54" y="30.48" visible="pin" length="short"/>
 <pin name="D25" x="-2.54" y="27.94" visible="pin" length="short"/>
 <pin name="D26" x="-2.54" y="25.4" visible="pin" length="short"/>
@@ -13401,11 +13560,11 @@ DC/DC</text>
 <pin name="A20" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
 <pin name="A21" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
 <pin name="A22" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
-<pin name="GND3" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
+<pin name="GND_1" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
 <pin name="VBAT" x="5.08" y="-2.54" visible="pin" length="short" rot="R90"/>
-<pin name="3.3V2" x="7.62" y="-2.54" visible="pin" length="short" rot="R90"/>
-<pin name="GND2" x="10.16" y="-2.54" visible="pin" length="short" rot="R90"/>
-<pin name="PRGM" x="12.7" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="3.3V_2" x="7.62" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="GND_2" x="10.16" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="PROG" x="12.7" y="-2.54" visible="pin" length="short" rot="R90"/>
 <pin name="RST" x="15.24" y="-2.54" visible="pin" length="short" rot="R90"/>
 </symbol>
 <symbol name="CR-2450/G1AN">
@@ -13881,7 +14040,7 @@ Demo Board</text>
 <wire x1="-3.81" y1="4.064" x2="-3.81" y2="8.89" width="0.254" layer="94"/>
 <wire x1="-3.81" y1="8.89" x2="0" y2="12.7" width="0.254" layer="94"/>
 </symbol>
-<symbol name="TEENSY_LC_EXT">
+<symbol name="TEENSY_LC">
 <pin name="D0(RX1)" x="-2.54" y="40.64" visible="pin" length="short"/>
 <pin name="D1(TX1)" x="-2.54" y="38.1" visible="pin" length="short"/>
 <pin name="GND" x="-2.54" y="43.18" visible="pin" length="short"/>
@@ -13889,12 +14048,12 @@ Demo Board</text>
 <wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
 <wire x1="20.32" y1="0" x2="20.32" y2="48.26" width="0.254" layer="94"/>
 <wire x1="20.32" y1="48.26" x2="0" y2="48.26" width="0.254" layer="94"/>
-<text x="2.54" y="45.72" size="1.778" layer="95">Teensy LC</text>
+<text x="5.08" y="45.72" size="1.778" layer="95">Teensy LC</text>
 <pin name="D2" x="-2.54" y="35.56" visible="pin" length="short"/>
-<pin name="D3" x="-2.54" y="33.02" visible="pin" length="short"/>
-<pin name="D4" x="-2.54" y="30.48" visible="pin" length="short"/>
-<pin name="D5" x="-2.54" y="27.94" visible="pin" length="short"/>
-<pin name="D6" x="-2.54" y="25.4" visible="pin" length="short"/>
+<pin name="D3(RX1)" x="-2.54" y="33.02" visible="pin" length="short"/>
+<pin name="D4(TX1)" x="-2.54" y="30.48" visible="pin" length="short"/>
+<pin name="D5(TX1)" x="-2.54" y="27.94" visible="pin" length="short"/>
+<pin name="D6(RX3)" x="-2.54" y="25.4" visible="pin" length="short"/>
 <pin name="D7(RX3)" x="-2.54" y="22.86" visible="pin" length="short"/>
 <pin name="D8(TX3)" x="-2.54" y="20.32" visible="pin" length="short"/>
 <pin name="D9(RX2)" x="-2.54" y="17.78" visible="pin" length="short"/>
@@ -13912,14 +14071,14 @@ Demo Board</text>
 <pin name="A7" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
 <pin name="A9" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
 <pin name="A8" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
-<pin name="3.3V2" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
 <pin name="VIN" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
 <pin name="AGND" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
-<pin name="D17" x="5.08" y="-2.54" visible="pin" length="short" rot="R90"/>
-<pin name="3.3V" x="7.62" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="17VIN" x="5.08" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="3.3V2" x="7.62" y="-2.54" visible="pin" length="short" rot="R90"/>
 <pin name="GND2" x="10.16" y="-2.54" visible="pin" length="short" rot="R90"/>
 <pin name="PGRM" x="12.7" y="-2.54" visible="pin" length="short" rot="R90"/>
-<pin name="DAC" x="15.24" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="A12" x="15.24" y="-2.54" visible="pin" length="short" rot="R90"/>
 </symbol>
 <symbol name="SN74LV1T34">
 <wire x1="0" y1="1.27" x2="0" y2="-2.54" width="0.254" layer="94"/>
@@ -14400,7 +14559,7 @@ Demo Board</text>
 <wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
 <wire x1="20.32" y1="0" x2="20.32" y2="48.26" width="0.254" layer="94"/>
 <wire x1="20.32" y1="48.26" x2="0" y2="48.26" width="0.254" layer="94"/>
-<text x="10.31875" y="45.72" size="1.778" layer="95" align="bottom-center">Teensy 3.2</text>
+<text x="4.064" y="45.72" size="1.778" layer="95">Teensy 3.2</text>
 <pin name="D2" x="-2.54" y="35.56" visible="pin" length="short"/>
 <pin name="D3(CANTX)" x="-2.54" y="33.02" visible="pin" length="short"/>
 <pin name="D4(CANRX)" x="-2.54" y="30.48" visible="pin" length="short"/>
@@ -14599,15 +14758,15 @@ Demo Board</text>
 <pin name="CANL" x="22.86" y="5.08" length="short" rot="R180"/>
 <pin name="GND2" x="22.86" y="2.54" length="short" rot="R180"/>
 </symbol>
-<symbol name="TEENSY_3.2_EXT_12ANALOG">
+<symbol name="TEENSY_3.2_12ANALOG">
 <pin name="D0(RX1)" x="-2.54" y="35.56" visible="pin" length="short"/>
 <pin name="D1(TX1)" x="-2.54" y="33.02" visible="pin" length="short"/>
 <pin name="GND" x="-2.54" y="38.1" visible="pin" length="short"/>
-<wire x1="0" y1="40.64" x2="0" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="0" y1="-2.54" x2="20.32" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="20.32" y1="-2.54" x2="20.32" y2="40.64" width="0.254" layer="94"/>
+<wire x1="0" y1="40.64" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
+<wire x1="20.32" y1="0" x2="20.32" y2="40.64" width="0.254" layer="94"/>
 <wire x1="20.32" y1="40.64" x2="0" y2="40.64" width="0.254" layer="94"/>
-<text x="10.31875" y="-1.27" size="1.778" layer="95" align="bottom-center">Teensy 3.2</text>
+<text x="5.08" y="1.27" size="1.778" layer="95">Teensy 3.2</text>
 <pin name="D2" x="-2.54" y="30.48" visible="pin" length="short"/>
 <pin name="D3(CANTX)" x="-2.54" y="27.94" visible="pin" length="short"/>
 <pin name="D4(CANRX)" x="-2.54" y="25.4" visible="pin" length="short"/>
@@ -14804,8 +14963,8 @@ Demo Board</text>
 <wire x1="0" y1="20.32" x2="0" y2="0" width="0.254" layer="94"/>
 <pin name="IP+" x="-5.08" y="15.24" length="middle"/>
 <pin name="IP-" x="-5.08" y="7.62" length="middle"/>
-<pin name="VOUT" x="22.86" y="12.7" length="middle" rot="R180"/>
-<pin name="VDD" x="22.86" y="17.78" length="middle" rot="R180"/>
+<pin name="VIOUT" x="22.86" y="12.7" length="middle" rot="R180"/>
+<pin name="VCC" x="22.86" y="17.78" length="middle" rot="R180"/>
 <pin name="FILTER" x="22.86" y="7.62" length="middle" rot="R180"/>
 <pin name="GND" x="22.86" y="2.54" length="middle" rot="R180"/>
 </symbol>
@@ -15060,286 +15219,6 @@ Demo Board</text>
 <wire x1="17.78" y1="0" x2="17.78" y2="2.54" width="0.254" layer="94"/>
 <wire x1="17.78" y1="2.54" x2="12.7" y2="2.54" width="0.254" layer="94"/>
 </symbol>
-<symbol name="TEENSY_4.0_EXT">
-<pin name="D0(RX1)" x="-2.54" y="40.64" visible="pin" length="short"/>
-<pin name="D1(TX1)" x="-2.54" y="38.1" visible="pin" length="short"/>
-<pin name="GND" x="-2.54" y="43.18" visible="pin" length="short"/>
-<wire x1="0" y1="48.26" x2="0" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="0" y1="-2.54" x2="20.32" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="20.32" y1="-2.54" x2="20.32" y2="48.26" width="0.254" layer="94"/>
-<wire x1="20.32" y1="48.26" x2="0" y2="48.26" width="0.254" layer="94"/>
-<text x="10.31875" y="45.72" size="1.778" layer="95" align="bottom-center">Teensy 4.0</text>
-<pin name="D2" x="-2.54" y="35.56" visible="pin" length="short"/>
-<pin name="D3" x="-2.54" y="33.02" visible="pin" length="short"/>
-<pin name="D4" x="-2.54" y="30.48" visible="pin" length="short"/>
-<pin name="D5" x="-2.54" y="27.94" visible="pin" length="short"/>
-<pin name="D6" x="-2.54" y="25.4" visible="pin" length="short"/>
-<pin name="D7(RX2)" x="-2.54" y="22.86" visible="pin" length="short"/>
-<pin name="D8(TX2\)" x="-2.54" y="20.32" visible="pin" length="short"/>
-<pin name="D9" x="-2.54" y="17.78" visible="pin" length="short"/>
-<pin name="D10" x="-2.54" y="15.24" visible="pin" length="short"/>
-<pin name="D11" x="-2.54" y="12.7" visible="pin" length="short"/>
-<pin name="D12" x="-2.54" y="10.16" visible="pin" length="short"/>
-<pin name="D13" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
-<pin name="(TX3)A0" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
-<pin name="(RX3)A1" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
-<pin name="A2" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
-<pin name="A3" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
-<pin name="A4" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
-<pin name="A6" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
-<pin name="A5" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
-<pin name="A7" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
-<pin name="(CANRX)A9" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
-<pin name="(CANTX)A8" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
-<pin name="3.3V2" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
-<pin name="VIN" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
-<pin name="GND3" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
-<pin name="VBAT" x="5.08" y="-5.08" visible="pin" length="short" rot="R90"/>
-<pin name="3.3V" x="7.62" y="-5.08" visible="pin" length="short" rot="R90"/>
-<pin name="GND2" x="10.16" y="-5.08" visible="pin" length="short" rot="R90"/>
-<pin name="PGRM" x="12.7" y="-5.08" visible="pin" length="short" rot="R90"/>
-<pin name="ON/OFF" x="15.24" y="-5.08" visible="pin" length="short" rot="R90"/>
-</symbol>
-<symbol name="TEENSY_4.0_SIMPLE">
-<pin name="D0(RX1)" x="-2.54" y="35.56" visible="pin" length="short"/>
-<pin name="D1(TX1)" x="-2.54" y="33.02" visible="pin" length="short"/>
-<pin name="GND" x="-2.54" y="38.1" visible="pin" length="short"/>
-<wire x1="0" y1="40.64" x2="0" y2="0" width="0.254" layer="94"/>
-<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
-<wire x1="20.32" y1="0" x2="20.32" y2="40.64" width="0.254" layer="94"/>
-<wire x1="20.32" y1="40.64" x2="0" y2="40.64" width="0.254" layer="94"/>
-<text x="10.31875" y="1.27" size="1.778" layer="95" align="bottom-center">Teensy 4.0</text>
-<pin name="D2" x="-2.54" y="30.48" visible="pin" length="short"/>
-<pin name="D3" x="-2.54" y="27.94" visible="pin" length="short"/>
-<pin name="D4" x="-2.54" y="25.4" visible="pin" length="short"/>
-<pin name="D5" x="-2.54" y="22.86" visible="pin" length="short"/>
-<pin name="D6" x="-2.54" y="20.32" visible="pin" length="short"/>
-<pin name="D7(RX2)" x="-2.54" y="17.78" visible="pin" length="short"/>
-<pin name="D8(TX2)" x="-2.54" y="15.24" visible="pin" length="short"/>
-<pin name="D9" x="-2.54" y="12.7" visible="pin" length="short"/>
-<pin name="D10" x="-2.54" y="10.16" visible="pin" length="short"/>
-<pin name="D11" x="-2.54" y="7.62" visible="pin" length="short"/>
-<pin name="D12" x="-2.54" y="5.08" visible="pin" length="short"/>
-<pin name="D13" x="22.86" y="5.08" visible="pin" length="short" rot="R180"/>
-<pin name="(TX3)A0" x="22.86" y="7.62" visible="pin" length="short" rot="R180"/>
-<pin name="(RX3)A1" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
-<pin name="A2" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
-<pin name="A3" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
-<pin name="A4" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
-<pin name="A6" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
-<pin name="A5" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
-<pin name="(CANTX)A7" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
-<pin name="A9" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
-<pin name="(CANRX)A8" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
-<pin name="3.3V" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
-<pin name="VIN" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
-<pin name="GND2" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
-</symbol>
-<symbol name="TEENSY_3.5_SIMPLE">
-<pin name="D0(RX1)" x="-2.54" y="66.04" visible="pin" length="short"/>
-<pin name="D1(TX1)" x="-2.54" y="63.5" visible="pin" length="short"/>
-<pin name="GND" x="-2.54" y="68.58" visible="pin" length="short"/>
-<wire x1="0" y1="71.12" x2="0" y2="5.08" width="0.254" layer="94"/>
-<wire x1="0" y1="5.08" x2="20.32" y2="5.08" width="0.254" layer="94"/>
-<wire x1="20.32" y1="5.08" x2="20.32" y2="71.12" width="0.254" layer="94"/>
-<wire x1="20.32" y1="71.12" x2="0" y2="71.12" width="0.254" layer="94"/>
-<pin name="D2" x="-2.54" y="60.96" visible="pin" length="short"/>
-<pin name="D3(CANTX)" x="-2.54" y="58.42" visible="pin" length="short"/>
-<pin name="D4(CANRX)" x="-2.54" y="55.88" visible="pin" length="short"/>
-<pin name="D5" x="-2.54" y="53.34" visible="pin" length="short"/>
-<pin name="D6" x="-2.54" y="50.8" visible="pin" length="short"/>
-<pin name="D7(RX3)" x="-2.54" y="48.26" visible="pin" length="short"/>
-<pin name="D8(TX3)" x="-2.54" y="45.72" visible="pin" length="short"/>
-<pin name="D9(RX2)" x="-2.54" y="43.18" visible="pin" length="short"/>
-<pin name="D10(TX2)" x="-2.54" y="40.64" visible="pin" length="short"/>
-<pin name="D11" x="-2.54" y="38.1" visible="pin" length="short"/>
-<pin name="D12" x="-2.54" y="35.56" visible="pin" length="short"/>
-<pin name="D13" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
-<pin name="A0" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
-<pin name="A1" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
-<pin name="A2" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
-<pin name="A3" x="22.86" y="45.72" visible="pin" length="short" rot="R180"/>
-<pin name="A4" x="22.86" y="48.26" visible="pin" length="short" rot="R180"/>
-<pin name="A6" x="22.86" y="53.34" visible="pin" length="short" rot="R180"/>
-<pin name="A5" x="22.86" y="50.8" visible="pin" length="short" rot="R180"/>
-<pin name="A7" x="22.86" y="55.88" visible="pin" length="short" rot="R180"/>
-<pin name="A9" x="22.86" y="60.96" visible="pin" length="short" rot="R180"/>
-<pin name="A8" x="22.86" y="58.42" visible="pin" length="short" rot="R180"/>
-<pin name="3.3V2" x="22.86" y="63.5" visible="pin" length="short" rot="R180"/>
-<pin name="VIN" x="22.86" y="68.58" visible="pin" length="short" rot="R180"/>
-<pin name="AGND" x="22.86" y="66.04" visible="pin" length="short" rot="R180"/>
-<pin name="3.3V" x="-2.54" y="33.02" visible="pin" length="short"/>
-<pin name="D24" x="-2.54" y="30.48" visible="pin" length="short"/>
-<pin name="D25" x="-2.54" y="27.94" visible="pin" length="short"/>
-<pin name="D26" x="-2.54" y="25.4" visible="pin" length="short"/>
-<pin name="D27" x="-2.54" y="22.86" visible="pin" length="short"/>
-<pin name="D28" x="-2.54" y="20.32" visible="pin" length="short"/>
-<pin name="D29" x="-2.54" y="17.78" visible="pin" length="short"/>
-<pin name="D30" x="-2.54" y="15.24" visible="pin" length="short"/>
-<pin name="A12" x="-2.54" y="12.7" visible="pin" length="short"/>
-<pin name="A13" x="-2.54" y="10.16" visible="pin" length="short"/>
-<pin name="A14" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
-<pin name="A15" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
-<pin name="A16" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
-<pin name="A17" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
-<pin name="A18" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
-<pin name="A19" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
-<pin name="A20" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
-<pin name="A21" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
-<pin name="A22" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
-<pin name="GND2" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
-<text x="10.31875" y="6.35" size="1.778" layer="95" align="bottom-center">Teensy 3.5</text>
-</symbol>
-<symbol name="TEENSY_3.6_EXT_RTC">
-<pin name="D0(RX1)" x="-2.54" y="66.04" visible="pin" length="short"/>
-<pin name="D1(TX1)" x="-2.54" y="63.5" visible="pin" length="short"/>
-<pin name="GND" x="-2.54" y="68.58" visible="pin" length="short"/>
-<wire x1="0" y1="73.66" x2="0" y2="0" width="0.254" layer="94"/>
-<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
-<wire x1="20.32" y1="0" x2="20.32" y2="73.66" width="0.254" layer="94"/>
-<wire x1="20.32" y1="73.66" x2="0" y2="73.66" width="0.254" layer="94"/>
-<text x="10.31875" y="70.866" size="1.778" layer="95" align="bottom-center">Teensy 3.6</text>
-<pin name="D2" x="-2.54" y="60.96" visible="pin" length="short"/>
-<pin name="D3(CANTX)" x="-2.54" y="58.42" visible="pin" length="short"/>
-<pin name="D4(CANRX)" x="-2.54" y="55.88" visible="pin" length="short"/>
-<pin name="D5" x="-2.54" y="53.34" visible="pin" length="short"/>
-<pin name="D6" x="-2.54" y="50.8" visible="pin" length="short"/>
-<pin name="D7(RX3)" x="-2.54" y="48.26" visible="pin" length="short"/>
-<pin name="D8(TX3)" x="-2.54" y="45.72" visible="pin" length="short"/>
-<pin name="D9(RX2)" x="-2.54" y="43.18" visible="pin" length="short"/>
-<pin name="D10(TX2)" x="-2.54" y="40.64" visible="pin" length="short"/>
-<pin name="D11" x="-2.54" y="38.1" visible="pin" length="short"/>
-<pin name="D12" x="-2.54" y="35.56" visible="pin" length="short"/>
-<pin name="D13" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
-<pin name="A0" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
-<pin name="A1" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
-<pin name="A2" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
-<pin name="A3" x="22.86" y="45.72" visible="pin" length="short" rot="R180"/>
-<pin name="A4" x="22.86" y="48.26" visible="pin" length="short" rot="R180"/>
-<pin name="A6" x="22.86" y="53.34" visible="pin" length="short" rot="R180"/>
-<pin name="A5" x="22.86" y="50.8" visible="pin" length="short" rot="R180"/>
-<pin name="A7" x="22.86" y="55.88" visible="pin" length="short" rot="R180"/>
-<pin name="A9" x="22.86" y="60.96" visible="pin" length="short" rot="R180"/>
-<pin name="A8" x="22.86" y="58.42" visible="pin" length="short" rot="R180"/>
-<pin name="3.3V3" x="22.86" y="63.5" visible="pin" length="short" rot="R180"/>
-<pin name="VIN" x="22.86" y="68.58" visible="pin" length="short" rot="R180"/>
-<pin name="AGND" x="22.86" y="66.04" visible="pin" length="short" rot="R180"/>
-<pin name="3.3V" x="-2.54" y="33.02" visible="pin" length="short"/>
-<pin name="D24" x="-2.54" y="30.48" visible="pin" length="short"/>
-<pin name="D25" x="-2.54" y="27.94" visible="pin" length="short"/>
-<pin name="D26" x="-2.54" y="25.4" visible="pin" length="short"/>
-<pin name="D27" x="-2.54" y="22.86" visible="pin" length="short"/>
-<pin name="D28" x="-2.54" y="20.32" visible="pin" length="short"/>
-<pin name="D29" x="-2.54" y="17.78" visible="pin" length="short"/>
-<pin name="D30" x="-2.54" y="15.24" visible="pin" length="short"/>
-<pin name="A12" x="-2.54" y="12.7" visible="pin" length="short"/>
-<pin name="A13" x="-2.54" y="10.16" visible="pin" length="short"/>
-<pin name="A14" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
-<pin name="A15" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
-<pin name="A16" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
-<pin name="A17" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
-<pin name="A18" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
-<pin name="A19" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
-<pin name="A20" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
-<pin name="A21" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
-<pin name="A22" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
-<pin name="GND3" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
-<pin name="VBAT" x="5.08" y="-2.54" visible="pin" length="short" rot="R90"/>
-<pin name="3.3V2" x="7.62" y="-2.54" visible="pin" length="short" rot="R90"/>
-<pin name="GND2" x="10.16" y="-2.54" visible="pin" length="short" rot="R90"/>
-<pin name="PRGM" x="12.7" y="-2.54" visible="pin" length="short" rot="R90"/>
-<pin name="RST" x="15.24" y="-2.54" visible="pin" length="short" rot="R90"/>
-</symbol>
-<symbol name="TEENSY_3.6_SIMPLE">
-<pin name="D0(RX1)" x="-2.54" y="66.04" visible="pin" length="short"/>
-<pin name="D1(TX1)" x="-2.54" y="63.5" visible="pin" length="short"/>
-<pin name="GND" x="-2.54" y="68.58" visible="pin" length="short"/>
-<wire x1="0" y1="71.12" x2="0" y2="5.08" width="0.254" layer="94"/>
-<wire x1="0" y1="5.08" x2="20.32" y2="5.08" width="0.254" layer="94"/>
-<wire x1="20.32" y1="5.08" x2="20.32" y2="71.12" width="0.254" layer="94"/>
-<wire x1="20.32" y1="71.12" x2="0" y2="71.12" width="0.254" layer="94"/>
-<pin name="D2" x="-2.54" y="60.96" visible="pin" length="short"/>
-<pin name="D3(CANTX)" x="-2.54" y="58.42" visible="pin" length="short"/>
-<pin name="D4(CANRX)" x="-2.54" y="55.88" visible="pin" length="short"/>
-<pin name="D5" x="-2.54" y="53.34" visible="pin" length="short"/>
-<pin name="D6" x="-2.54" y="50.8" visible="pin" length="short"/>
-<pin name="D7(RX3)" x="-2.54" y="48.26" visible="pin" length="short"/>
-<pin name="D8(TX3)" x="-2.54" y="45.72" visible="pin" length="short"/>
-<pin name="D9(RX2)" x="-2.54" y="43.18" visible="pin" length="short"/>
-<pin name="D10(TX2)" x="-2.54" y="40.64" visible="pin" length="short"/>
-<pin name="D11" x="-2.54" y="38.1" visible="pin" length="short"/>
-<pin name="D12" x="-2.54" y="35.56" visible="pin" length="short"/>
-<pin name="D13" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
-<pin name="A0" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
-<pin name="A1" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
-<pin name="A2" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
-<pin name="A3" x="22.86" y="45.72" visible="pin" length="short" rot="R180"/>
-<pin name="A4" x="22.86" y="48.26" visible="pin" length="short" rot="R180"/>
-<pin name="A6" x="22.86" y="53.34" visible="pin" length="short" rot="R180"/>
-<pin name="A5" x="22.86" y="50.8" visible="pin" length="short" rot="R180"/>
-<pin name="A7" x="22.86" y="55.88" visible="pin" length="short" rot="R180"/>
-<pin name="A9" x="22.86" y="60.96" visible="pin" length="short" rot="R180"/>
-<pin name="A8" x="22.86" y="58.42" visible="pin" length="short" rot="R180"/>
-<pin name="3.3V2" x="22.86" y="63.5" visible="pin" length="short" rot="R180"/>
-<pin name="VIN" x="22.86" y="68.58" visible="pin" length="short" rot="R180"/>
-<pin name="AGND" x="22.86" y="66.04" visible="pin" length="short" rot="R180"/>
-<pin name="3.3V" x="-2.54" y="33.02" visible="pin" length="short"/>
-<pin name="D24" x="-2.54" y="30.48" visible="pin" length="short"/>
-<pin name="D25" x="-2.54" y="27.94" visible="pin" length="short"/>
-<pin name="D26" x="-2.54" y="25.4" visible="pin" length="short"/>
-<pin name="D27" x="-2.54" y="22.86" visible="pin" length="short"/>
-<pin name="D28" x="-2.54" y="20.32" visible="pin" length="short"/>
-<pin name="D29" x="-2.54" y="17.78" visible="pin" length="short"/>
-<pin name="D30" x="-2.54" y="15.24" visible="pin" length="short"/>
-<pin name="A12" x="-2.54" y="12.7" visible="pin" length="short"/>
-<pin name="A13" x="-2.54" y="10.16" visible="pin" length="short"/>
-<pin name="A14" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
-<pin name="A15" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
-<pin name="A16" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
-<pin name="A17" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
-<pin name="A18" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
-<pin name="A19" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
-<pin name="A20" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
-<pin name="A21" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
-<pin name="A22" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
-<pin name="GND2" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
-<text x="2.54" y="6.35" size="1.778" layer="95">Teensy 3.6</text>
-</symbol>
-<symbol name="TEENSY_LC_SIMPLE">
-<pin name="D0(RX1)" x="-2.54" y="40.64" visible="pin" length="short"/>
-<pin name="D1(TX1)" x="-2.54" y="38.1" visible="pin" length="short"/>
-<pin name="GND" x="-2.54" y="43.18" visible="pin" length="short"/>
-<wire x1="0" y1="45.72" x2="0" y2="5.08" width="0.254" layer="94"/>
-<wire x1="0" y1="5.08" x2="20.32" y2="5.08" width="0.254" layer="94"/>
-<wire x1="20.32" y1="5.08" x2="20.32" y2="45.72" width="0.254" layer="94"/>
-<wire x1="20.32" y1="45.72" x2="0" y2="45.72" width="0.254" layer="94"/>
-<pin name="D2" x="-2.54" y="35.56" visible="pin" length="short"/>
-<pin name="D3" x="-2.54" y="33.02" visible="pin" length="short"/>
-<pin name="D4" x="-2.54" y="30.48" visible="pin" length="short"/>
-<pin name="D5" x="-2.54" y="27.94" visible="pin" length="short"/>
-<pin name="D6" x="-2.54" y="25.4" visible="pin" length="short"/>
-<pin name="D7(RX3)" x="-2.54" y="22.86" visible="pin" length="short"/>
-<pin name="D8(TX3)" x="-2.54" y="20.32" visible="pin" length="short"/>
-<pin name="D9(RX2)" x="-2.54" y="17.78" visible="pin" length="short"/>
-<pin name="D10(TX2)" x="-2.54" y="15.24" visible="pin" length="short"/>
-<pin name="D11" x="-2.54" y="12.7" visible="pin" length="short"/>
-<pin name="D12" x="-2.54" y="10.16" visible="pin" length="short"/>
-<pin name="D13" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
-<pin name="A0" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
-<pin name="A1" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
-<pin name="A2" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
-<pin name="A3" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
-<pin name="A4" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
-<pin name="A6" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
-<pin name="A5" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
-<pin name="A7" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
-<pin name="A9" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
-<pin name="A8" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
-<pin name="3.3V" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
-<pin name="VIN" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
-<pin name="AGND" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
-<text x="2.54" y="6.35" size="1.778" layer="95">Teensy LC</text>
-</symbol>
 <symbol name="JUMPER_SWITCH_2">
 <polygon width="0.254" layer="94">
 <vertex x="1.27" y="1.27" curve="-90"/>
@@ -15403,59 +15282,94 @@ Demo Board</text>
 <pin name="4" x="2.54" y="-5.08" visible="off" length="short" direction="pas" rot="R90"/>
 <pin name="2" x="0" y="-5.08" visible="off" length="short" direction="pas" rot="R90"/>
 </symbol>
-<symbol name="ACHS-7121">
-<wire x1="0" y1="0" x2="17.78" y2="0" width="0.254" layer="94"/>
-<wire x1="17.78" y1="0" x2="17.78" y2="20.32" width="0.254" layer="94"/>
-<wire x1="17.78" y1="20.32" x2="0" y2="20.32" width="0.254" layer="94"/>
-<wire x1="0" y1="20.32" x2="0" y2="0" width="0.254" layer="94"/>
-<pin name="IP+" x="-5.08" y="15.24" length="middle"/>
-<pin name="IP-" x="-5.08" y="7.62" length="middle"/>
-<pin name="VOUT" x="22.86" y="12.7" length="middle" rot="R180"/>
-<pin name="VDD" x="22.86" y="17.78" length="middle" rot="R180"/>
-<pin name="FILTER" x="22.86" y="7.62" length="middle" rot="R180"/>
-<pin name="GND" x="22.86" y="2.54" length="middle" rot="R180"/>
+<symbol name="LTC6811-2">
+<wire x1="20.32" y1="0" x2="20.32" y2="-63.5" width="0.254" layer="94"/>
+<wire x1="20.32" y1="-63.5" x2="0" y2="-63.5" width="0.254" layer="94"/>
+<wire x1="0" y1="-63.5" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
+<pin name="A3" x="22.86" y="-2.54" length="short" rot="R180"/>
+<pin name="A2" x="22.86" y="-5.08" length="short" rot="R180"/>
+<pin name="A1" x="22.86" y="-7.62" length="short" rot="R180"/>
+<pin name="A0" x="22.86" y="-10.16" length="short" rot="R180"/>
+<pin name="SDO(IBIAS)" x="22.86" y="-12.7" length="short" rot="R180"/>
+<pin name="SDI(ICMP)" x="22.86" y="-15.24" length="short" rot="R180"/>
+<pin name="SCK(IPA)" x="22.86" y="-17.78" length="short" rot="R180"/>
+<pin name="CSB(IMA)" x="22.86" y="-20.32" length="short" rot="R180"/>
+<pin name="ISOMD" x="22.86" y="-22.86" length="short" rot="R180"/>
+<pin name="WDT" x="22.86" y="-25.4" length="short" rot="R180"/>
+<pin name="DRIVE" x="22.86" y="-27.94" length="short" rot="R180"/>
+<pin name="VREG" x="22.86" y="-30.48" length="short" rot="R180"/>
+<pin name="SWTEN" x="22.86" y="-33.02" length="short" rot="R180"/>
+<pin name="VREF1" x="22.86" y="-35.56" length="short" rot="R180"/>
+<pin name="VREF2" x="22.86" y="-38.1" length="short" rot="R180"/>
+<pin name="GPI05" x="22.86" y="-40.64" length="short" rot="R180"/>
+<pin name="GPI04" x="22.86" y="-43.18" length="short" rot="R180"/>
+<pin name="V-" x="22.86" y="-45.72" length="short" rot="R180"/>
+<pin name="V-**" x="22.86" y="-48.26" length="short" rot="R180"/>
+<pin name="GPI03" x="22.86" y="-50.8" length="short" rot="R180"/>
+<pin name="GPI02" x="22.86" y="-53.34" length="short" rot="R180"/>
+<pin name="GPI01" x="22.86" y="-55.88" length="short" rot="R180"/>
+<pin name="C0" x="22.86" y="-58.42" length="short" rot="R180"/>
+<pin name="S1" x="22.86" y="-60.96" length="short" rot="R180"/>
+<pin name="C1" x="-2.54" y="-60.96" length="short"/>
+<pin name="S2" x="-2.54" y="-58.42" length="short"/>
+<pin name="C2" x="-2.54" y="-55.88" length="short"/>
+<pin name="S3" x="-2.54" y="-53.34" length="short"/>
+<pin name="C3" x="-2.54" y="-50.8" length="short"/>
+<pin name="S4" x="-2.54" y="-48.26" length="short"/>
+<pin name="C4" x="-2.54" y="-45.72" length="short"/>
+<pin name="S5" x="-2.54" y="-43.18" length="short"/>
+<pin name="C5" x="-2.54" y="-40.64" length="short"/>
+<pin name="S6" x="-2.54" y="-38.1" length="short"/>
+<pin name="C6" x="-2.54" y="-35.56" length="short"/>
+<pin name="S7" x="-2.54" y="-33.02" length="short"/>
+<pin name="C7" x="-2.54" y="-30.48" length="short"/>
+<pin name="S8" x="-2.54" y="-27.94" length="short"/>
+<pin name="C8" x="-2.54" y="-25.4" length="short"/>
+<pin name="S9" x="-2.54" y="-22.86" length="short"/>
+<pin name="C9" x="-2.54" y="-20.32" length="short"/>
+<pin name="S10" x="-2.54" y="-17.78" length="short"/>
+<pin name="C10" x="-2.54" y="-15.24" length="short"/>
+<pin name="S11" x="-2.54" y="-12.7" length="short"/>
+<pin name="C11" x="-2.54" y="-10.16" length="short"/>
+<pin name="S12" x="-2.54" y="-7.62" length="short"/>
+<pin name="C12" x="-2.54" y="-5.08" length="short"/>
+<pin name="V+" x="-2.54" y="-2.54" length="short"/>
 </symbol>
-<symbol name="LTC6081IMS8PBF">
-<pin name="OUTA" x="2.54" y="0" length="middle" direction="out"/>
-<pin name="-INA" x="2.54" y="-2.54" length="middle" direction="in"/>
-<pin name="+INA" x="2.54" y="-5.08" length="middle" direction="in"/>
-<pin name="V-" x="2.54" y="-7.62" length="middle" direction="pwr"/>
-<pin name="+INB" x="58.42" y="-7.62" length="middle" direction="in" rot="R180"/>
-<pin name="-INB" x="58.42" y="-5.08" length="middle" direction="in" rot="R180"/>
-<pin name="OUTB" x="58.42" y="-2.54" length="middle" direction="out" rot="R180"/>
-<pin name="V+" x="58.42" y="0" length="middle" direction="pwr" rot="R180"/>
-<wire x1="7.62" y1="5.08" x2="7.62" y2="-12.7" width="0.1524" layer="94"/>
-<wire x1="7.62" y1="-12.7" x2="53.34" y2="-12.7" width="0.1524" layer="94"/>
-<wire x1="53.34" y1="-12.7" x2="53.34" y2="5.08" width="0.1524" layer="94"/>
-<wire x1="53.34" y1="5.08" x2="7.62" y2="5.08" width="0.1524" layer="94"/>
-<text x="25.7556" y="9.1186" size="2.0828" layer="95" ratio="6" rot="SR0">&gt;Name</text>
-<text x="25.1206" y="6.5786" size="2.0828" layer="96" ratio="6" rot="SR0">&gt;Value</text>
-</symbol>
-<symbol name="MAX31855KASA+">
-<pin name="GND" x="2.54" y="0" length="middle" direction="pwr"/>
-<pin name="T-" x="2.54" y="-2.54" length="middle" direction="in"/>
-<pin name="T+" x="2.54" y="-5.08" length="middle" direction="in"/>
-<pin name="VCC" x="2.54" y="-7.62" length="middle" direction="pwr"/>
-<pin name="SCK" x="27.94" y="-7.62" length="middle" direction="in" rot="R180"/>
-<pin name="!CS" x="27.94" y="-5.08" length="middle" direction="pas" rot="R180"/>
-<pin name="SO" x="27.94" y="-2.54" length="middle" direction="out" rot="R180"/>
-<pin name="DNC" x="27.94" y="0" length="middle" direction="nc" rot="R180"/>
-<wire x1="7.62" y1="2.54" x2="7.62" y2="-10.16" width="0.1524" layer="94"/>
-<wire x1="7.62" y1="-10.16" x2="22.86" y2="-10.16" width="0.1524" layer="94"/>
-<wire x1="22.86" y1="-10.16" x2="22.86" y2="2.54" width="0.1524" layer="94"/>
-<wire x1="22.86" y1="2.54" x2="7.62" y2="2.54" width="0.1524" layer="94"/>
-<text x="10.5156" y="6.5786" size="2.0828" layer="95" ratio="6" rot="SR0">&gt;Name</text>
-<text x="9.8806" y="4.0386" size="2.0828" layer="96" ratio="6" rot="SR0">&gt;Value</text>
-</symbol>
-<symbol name="PCC-SMP-K-100-R-ROHS">
-<wire x1="5.08" y1="2.54" x2="15.24" y2="2.54" width="0.254" layer="94"/>
-<wire x1="15.24" y1="-2.54" x2="15.24" y2="2.54" width="0.254" layer="94"/>
-<wire x1="15.24" y1="-2.54" x2="5.08" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="5.08" y1="2.54" x2="5.08" y2="-2.54" width="0.254" layer="94"/>
-<text x="16.51" y="7.62" size="1.778" layer="95" align="center-left">&gt;NAME</text>
-<text x="16.51" y="5.08" size="1.778" layer="96" align="center-left">&gt;VALUE</text>
-<pin name="+" x="0" y="0" length="middle"/>
-<pin name="-" x="20.32" y="0" length="middle" rot="R180"/>
+<symbol name="TEENSY_4.0_SIMPLE">
+<pin name="D0(RX1)" x="-2.54" y="35.56" visible="pin" length="short"/>
+<pin name="D1(TX1)" x="-2.54" y="33.02" visible="pin" length="short"/>
+<pin name="GND" x="-2.54" y="38.1" visible="pin" length="short"/>
+<wire x1="0" y1="40.64" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
+<wire x1="20.32" y1="0" x2="20.32" y2="40.64" width="0.254" layer="94"/>
+<wire x1="20.32" y1="40.64" x2="0" y2="40.64" width="0.254" layer="94"/>
+<text x="10.31875" y="1.27" size="1.778" layer="95" align="bottom-center">Teensy 4.0</text>
+<pin name="D2" x="-2.54" y="30.48" visible="pin" length="short"/>
+<pin name="D3" x="-2.54" y="27.94" visible="pin" length="short"/>
+<pin name="D4" x="-2.54" y="25.4" visible="pin" length="short"/>
+<pin name="D5" x="-2.54" y="22.86" visible="pin" length="short"/>
+<pin name="D6" x="-2.54" y="20.32" visible="pin" length="short"/>
+<pin name="D7(RX2)" x="-2.54" y="17.78" visible="pin" length="short"/>
+<pin name="D8(TX2)" x="-2.54" y="15.24" visible="pin" length="short"/>
+<pin name="D9" x="-2.54" y="12.7" visible="pin" length="short"/>
+<pin name="D10" x="-2.54" y="10.16" visible="pin" length="short"/>
+<pin name="D11" x="-2.54" y="7.62" visible="pin" length="short"/>
+<pin name="D12" x="-2.54" y="5.08" visible="pin" length="short"/>
+<pin name="D13" x="22.86" y="5.08" visible="pin" length="short" rot="R180"/>
+<pin name="(TX3)A0" x="22.86" y="7.62" visible="pin" length="short" rot="R180"/>
+<pin name="(RX3)A1" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
+<pin name="A2" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
+<pin name="A3" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
+<pin name="A4" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
+<pin name="A6" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
+<pin name="A5" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
+<pin name="(CANTX)A7" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
+<pin name="A9" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
+<pin name="(CANRX)A8" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
+<pin name="VIN" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
+<pin name="GND2" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
 </symbol>
 <symbol name="AUTOSPORT22">
 <wire x1="6.35" y1="-58.42" x2="0" y2="-58.42" width="0.4064" layer="94"/>
@@ -15508,6 +15422,150 @@ Demo Board</text>
 <pin name="21" x="10.16" y="-5.08" length="middle" direction="pas" swaplevel="1" rot="R180"/>
 <wire x1="3.81" y1="-2.54" x2="5.08" y2="-2.54" width="0.6096" layer="94"/>
 <pin name="22" x="10.16" y="-2.54" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+</symbol>
+<symbol name="LTC6804-1">
+<wire x1="20.32" y1="0" x2="20.32" y2="-63.5" width="0.254" layer="94"/>
+<wire x1="20.32" y1="-63.5" x2="0" y2="-63.5" width="0.254" layer="94"/>
+<wire x1="0" y1="-63.5" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
+<pin name="IPB" x="22.86" y="-2.54" length="short" rot="R180"/>
+<pin name="IMB" x="22.86" y="-5.08" length="short" rot="R180"/>
+<pin name="ICMP" x="22.86" y="-7.62" length="short" rot="R180"/>
+<pin name="IBIAS" x="22.86" y="-10.16" length="short" rot="R180"/>
+<pin name="SDO(NC)" x="22.86" y="-12.7" length="short" rot="R180"/>
+<pin name="SDI(NC)" x="22.86" y="-15.24" length="short" rot="R180"/>
+<pin name="SCK(IPA)" x="22.86" y="-17.78" length="short" rot="R180"/>
+<pin name="CSB(IMA)" x="22.86" y="-20.32" length="short" rot="R180"/>
+<pin name="ISOMD" x="22.86" y="-22.86" length="short" rot="R180"/>
+<pin name="WDT" x="22.86" y="-25.4" length="short" rot="R180"/>
+<pin name="DRIVE" x="22.86" y="-27.94" length="short" rot="R180"/>
+<pin name="VREG" x="22.86" y="-30.48" length="short" rot="R180"/>
+<pin name="SWTEN" x="22.86" y="-33.02" length="short" rot="R180"/>
+<pin name="VREF1" x="22.86" y="-35.56" length="short" rot="R180"/>
+<pin name="VREF2" x="22.86" y="-38.1" length="short" rot="R180"/>
+<pin name="GPI05" x="22.86" y="-40.64" length="short" rot="R180"/>
+<pin name="GPI04" x="22.86" y="-43.18" length="short" rot="R180"/>
+<pin name="V-" x="22.86" y="-45.72" length="short" rot="R180"/>
+<pin name="V-**" x="22.86" y="-48.26" length="short" rot="R180"/>
+<pin name="GPI03" x="22.86" y="-50.8" length="short" rot="R180"/>
+<pin name="GPI02" x="22.86" y="-53.34" length="short" rot="R180"/>
+<pin name="GPI01" x="22.86" y="-55.88" length="short" rot="R180"/>
+<pin name="C0" x="22.86" y="-58.42" length="short" rot="R180"/>
+<pin name="S1" x="22.86" y="-60.96" length="short" rot="R180"/>
+<pin name="C1" x="-2.54" y="-60.96" length="short"/>
+<pin name="S2" x="-2.54" y="-58.42" length="short"/>
+<pin name="C2" x="-2.54" y="-55.88" length="short"/>
+<pin name="S3" x="-2.54" y="-53.34" length="short"/>
+<pin name="C3" x="-2.54" y="-50.8" length="short"/>
+<pin name="S4" x="-2.54" y="-48.26" length="short"/>
+<pin name="C4" x="-2.54" y="-45.72" length="short"/>
+<pin name="S5" x="-2.54" y="-43.18" length="short"/>
+<pin name="C5" x="-2.54" y="-40.64" length="short"/>
+<pin name="S6" x="-2.54" y="-38.1" length="short"/>
+<pin name="C6" x="-2.54" y="-35.56" length="short"/>
+<pin name="S7" x="-2.54" y="-33.02" length="short"/>
+<pin name="C7" x="-2.54" y="-30.48" length="short"/>
+<pin name="S8" x="-2.54" y="-27.94" length="short"/>
+<pin name="C8" x="-2.54" y="-25.4" length="short"/>
+<pin name="S9" x="-2.54" y="-22.86" length="short"/>
+<pin name="C9" x="-2.54" y="-20.32" length="short"/>
+<pin name="S10" x="-2.54" y="-17.78" length="short"/>
+<pin name="C10" x="-2.54" y="-15.24" length="short"/>
+<pin name="S11" x="-2.54" y="-12.7" length="short"/>
+<pin name="C11" x="-2.54" y="-10.16" length="short"/>
+<pin name="S12" x="-2.54" y="-7.62" length="short"/>
+<pin name="C12" x="-2.54" y="-5.08" length="short"/>
+<pin name="V+" x="-2.54" y="-2.54" length="short"/>
+</symbol>
+<symbol name="TEENSY_LC_SIMPLE">
+<pin name="D0(RX1)" x="-2.54" y="40.64" visible="pin" length="short"/>
+<pin name="D1(TX1)" x="-2.54" y="38.1" visible="pin" length="short"/>
+<pin name="GND" x="-2.54" y="43.18" visible="pin" length="short"/>
+<wire x1="0" y1="45.72" x2="0" y2="5.08" width="0.254" layer="94"/>
+<wire x1="0" y1="5.08" x2="20.32" y2="5.08" width="0.254" layer="94"/>
+<wire x1="20.32" y1="5.08" x2="20.32" y2="45.72" width="0.254" layer="94"/>
+<wire x1="20.32" y1="45.72" x2="0" y2="45.72" width="0.254" layer="94"/>
+<pin name="D2" x="-2.54" y="35.56" visible="pin" length="short"/>
+<pin name="D3" x="-2.54" y="33.02" visible="pin" length="short"/>
+<pin name="D4" x="-2.54" y="30.48" visible="pin" length="short"/>
+<pin name="D5" x="-2.54" y="27.94" visible="pin" length="short"/>
+<pin name="D6" x="-2.54" y="25.4" visible="pin" length="short"/>
+<pin name="D7(RX3)" x="-2.54" y="22.86" visible="pin" length="short"/>
+<pin name="D8(TX3)" x="-2.54" y="20.32" visible="pin" length="short"/>
+<pin name="D9(RX2)" x="-2.54" y="17.78" visible="pin" length="short"/>
+<pin name="D10(TX2)" x="-2.54" y="15.24" visible="pin" length="short"/>
+<pin name="D11" x="-2.54" y="12.7" visible="pin" length="short"/>
+<pin name="D12" x="-2.54" y="10.16" visible="pin" length="short"/>
+<pin name="D13" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
+<pin name="A0" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
+<pin name="A1" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
+<pin name="A2" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
+<pin name="A3" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
+<pin name="A4" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
+<pin name="A6" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
+<pin name="A5" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
+<pin name="A7" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
+<pin name="A9" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
+<pin name="A8" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
+<pin name="VIN" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
+<pin name="AGND" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
+<text x="2.54" y="6.35" size="1.778" layer="95">Teensy LC</text>
+</symbol>
+<symbol name="TEENSY_3.6_SIMPLE">
+<pin name="D0(RX1)" x="-2.54" y="66.04" visible="pin" length="short"/>
+<pin name="D1(TX1)" x="-2.54" y="63.5" visible="pin" length="short"/>
+<pin name="GND" x="-2.54" y="68.58" visible="pin" length="short"/>
+<wire x1="0" y1="71.12" x2="0" y2="5.08" width="0.254" layer="94"/>
+<wire x1="0" y1="5.08" x2="20.32" y2="5.08" width="0.254" layer="94"/>
+<wire x1="20.32" y1="5.08" x2="20.32" y2="71.12" width="0.254" layer="94"/>
+<wire x1="20.32" y1="71.12" x2="0" y2="71.12" width="0.254" layer="94"/>
+<pin name="D2" x="-2.54" y="60.96" visible="pin" length="short"/>
+<pin name="D3(CANTX)" x="-2.54" y="58.42" visible="pin" length="short"/>
+<pin name="D4(CANRX)" x="-2.54" y="55.88" visible="pin" length="short"/>
+<pin name="D5" x="-2.54" y="53.34" visible="pin" length="short"/>
+<pin name="D6" x="-2.54" y="50.8" visible="pin" length="short"/>
+<pin name="D7(RX3)" x="-2.54" y="48.26" visible="pin" length="short"/>
+<pin name="D8(TX3)" x="-2.54" y="45.72" visible="pin" length="short"/>
+<pin name="D9(RX2)" x="-2.54" y="43.18" visible="pin" length="short"/>
+<pin name="D10(TX2)" x="-2.54" y="40.64" visible="pin" length="short"/>
+<pin name="D11" x="-2.54" y="38.1" visible="pin" length="short"/>
+<pin name="D12" x="-2.54" y="35.56" visible="pin" length="short"/>
+<pin name="D13" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
+<pin name="A0" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
+<pin name="A1" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
+<pin name="A2" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
+<pin name="A3" x="22.86" y="45.72" visible="pin" length="short" rot="R180"/>
+<pin name="A4" x="22.86" y="48.26" visible="pin" length="short" rot="R180"/>
+<pin name="A6" x="22.86" y="53.34" visible="pin" length="short" rot="R180"/>
+<pin name="A5" x="22.86" y="50.8" visible="pin" length="short" rot="R180"/>
+<pin name="A7" x="22.86" y="55.88" visible="pin" length="short" rot="R180"/>
+<pin name="A9" x="22.86" y="60.96" visible="pin" length="short" rot="R180"/>
+<pin name="A8" x="22.86" y="58.42" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V2" x="22.86" y="63.5" visible="pin" length="short" rot="R180"/>
+<pin name="VIN" x="22.86" y="68.58" visible="pin" length="short" rot="R180"/>
+<pin name="AGND" x="22.86" y="66.04" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V" x="-2.54" y="33.02" visible="pin" length="short"/>
+<pin name="D24" x="-2.54" y="30.48" visible="pin" length="short"/>
+<pin name="D25" x="-2.54" y="27.94" visible="pin" length="short"/>
+<pin name="D26" x="-2.54" y="25.4" visible="pin" length="short"/>
+<pin name="D27" x="-2.54" y="22.86" visible="pin" length="short"/>
+<pin name="D28" x="-2.54" y="20.32" visible="pin" length="short"/>
+<pin name="D29" x="-2.54" y="17.78" visible="pin" length="short"/>
+<pin name="D30" x="-2.54" y="15.24" visible="pin" length="short"/>
+<pin name="A12" x="-2.54" y="12.7" visible="pin" length="short"/>
+<pin name="A13" x="-2.54" y="10.16" visible="pin" length="short"/>
+<pin name="A14" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
+<pin name="A15" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
+<pin name="A16" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
+<pin name="A17" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
+<pin name="A18" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
+<pin name="A19" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
+<pin name="A20" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
+<pin name="A21" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
+<pin name="A22" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
+<pin name="GND2" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
+<text x="2.54" y="6.35" size="1.778" layer="95">Teensy 3.6</text>
 </symbol>
 <symbol name="LTC6082CGNPBF">
 <pin name="OUTA" x="2.54" y="0" length="middle" direction="out"/>
@@ -15639,6 +15697,198 @@ Demo Board</text>
 <wire x1="-6.604" y1="-12.7" x2="-7.112" y2="-12.7" width="0.1524" layer="94"/>
 <wire x1="-6.858" y1="-10.16" x2="-7.112" y2="-10.16" width="0.1524" layer="94"/>
 </symbol>
+<symbol name="TEENSY_4.0_EXT">
+<pin name="D0(RX1)" x="-2.54" y="40.64" visible="pin" length="short"/>
+<pin name="D1(TX1)" x="-2.54" y="38.1" visible="pin" length="short"/>
+<pin name="GND" x="-2.54" y="43.18" visible="pin" length="short"/>
+<wire x1="0" y1="48.26" x2="0" y2="-2.54" width="0.254" layer="94"/>
+<wire x1="0" y1="-2.54" x2="20.32" y2="-2.54" width="0.254" layer="94"/>
+<wire x1="20.32" y1="-2.54" x2="20.32" y2="48.26" width="0.254" layer="94"/>
+<wire x1="20.32" y1="48.26" x2="0" y2="48.26" width="0.254" layer="94"/>
+<text x="10.31875" y="45.72" size="1.778" layer="95" align="bottom-center">Teensy 4.0</text>
+<pin name="D2" x="-2.54" y="35.56" visible="pin" length="short"/>
+<pin name="D3" x="-2.54" y="33.02" visible="pin" length="short"/>
+<pin name="D4" x="-2.54" y="30.48" visible="pin" length="short"/>
+<pin name="D5" x="-2.54" y="27.94" visible="pin" length="short"/>
+<pin name="D6" x="-2.54" y="25.4" visible="pin" length="short"/>
+<pin name="D7(RX2)" x="-2.54" y="22.86" visible="pin" length="short"/>
+<pin name="D8(TX2\)" x="-2.54" y="20.32" visible="pin" length="short"/>
+<pin name="D9" x="-2.54" y="17.78" visible="pin" length="short"/>
+<pin name="D10" x="-2.54" y="15.24" visible="pin" length="short"/>
+<pin name="D11" x="-2.54" y="12.7" visible="pin" length="short"/>
+<pin name="D12" x="-2.54" y="10.16" visible="pin" length="short"/>
+<pin name="D13" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
+<pin name="(TX3)A0" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
+<pin name="(RX3)A1" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
+<pin name="A2" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
+<pin name="A3" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
+<pin name="A4" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
+<pin name="A6" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
+<pin name="A5" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
+<pin name="A7" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
+<pin name="(CANRX)A9" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
+<pin name="(CANTX)A8" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V2" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
+<pin name="VIN" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
+<pin name="GND3" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
+<pin name="VBAT" x="5.08" y="-5.08" visible="pin" length="short" rot="R90"/>
+<pin name="3.3V" x="7.62" y="-5.08" visible="pin" length="short" rot="R90"/>
+<pin name="GND2" x="10.16" y="-5.08" visible="pin" length="short" rot="R90"/>
+<pin name="PGRM" x="12.7" y="-5.08" visible="pin" length="short" rot="R90"/>
+<pin name="ON/OFF" x="15.24" y="-5.08" visible="pin" length="short" rot="R90"/>
+</symbol>
+<symbol name="TEENSY_3.6_EXT_RTC">
+<pin name="D0(RX1)" x="-2.54" y="66.04" visible="pin" length="short"/>
+<pin name="D1(TX1)" x="-2.54" y="63.5" visible="pin" length="short"/>
+<pin name="GND" x="-2.54" y="68.58" visible="pin" length="short"/>
+<wire x1="0" y1="73.66" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
+<wire x1="20.32" y1="0" x2="20.32" y2="73.66" width="0.254" layer="94"/>
+<wire x1="20.32" y1="73.66" x2="0" y2="73.66" width="0.254" layer="94"/>
+<text x="10.31875" y="70.866" size="1.778" layer="95" align="bottom-center">Teensy 3.6</text>
+<pin name="D2" x="-2.54" y="60.96" visible="pin" length="short"/>
+<pin name="D3(CANTX)" x="-2.54" y="58.42" visible="pin" length="short"/>
+<pin name="D4(CANRX)" x="-2.54" y="55.88" visible="pin" length="short"/>
+<pin name="D5" x="-2.54" y="53.34" visible="pin" length="short"/>
+<pin name="D6" x="-2.54" y="50.8" visible="pin" length="short"/>
+<pin name="D7(RX3)" x="-2.54" y="48.26" visible="pin" length="short"/>
+<pin name="D8(TX3)" x="-2.54" y="45.72" visible="pin" length="short"/>
+<pin name="D9(RX2)" x="-2.54" y="43.18" visible="pin" length="short"/>
+<pin name="D10(TX2)" x="-2.54" y="40.64" visible="pin" length="short"/>
+<pin name="D11" x="-2.54" y="38.1" visible="pin" length="short"/>
+<pin name="D12" x="-2.54" y="35.56" visible="pin" length="short"/>
+<pin name="D13" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
+<pin name="A0" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
+<pin name="A1" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
+<pin name="A2" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
+<pin name="A3" x="22.86" y="45.72" visible="pin" length="short" rot="R180"/>
+<pin name="A4" x="22.86" y="48.26" visible="pin" length="short" rot="R180"/>
+<pin name="A6" x="22.86" y="53.34" visible="pin" length="short" rot="R180"/>
+<pin name="A5" x="22.86" y="50.8" visible="pin" length="short" rot="R180"/>
+<pin name="A7" x="22.86" y="55.88" visible="pin" length="short" rot="R180"/>
+<pin name="A9" x="22.86" y="60.96" visible="pin" length="short" rot="R180"/>
+<pin name="A8" x="22.86" y="58.42" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V3" x="22.86" y="63.5" visible="pin" length="short" rot="R180"/>
+<pin name="VIN" x="22.86" y="68.58" visible="pin" length="short" rot="R180"/>
+<pin name="AGND" x="22.86" y="66.04" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V" x="-2.54" y="33.02" visible="pin" length="short"/>
+<pin name="D24" x="-2.54" y="30.48" visible="pin" length="short"/>
+<pin name="D25" x="-2.54" y="27.94" visible="pin" length="short"/>
+<pin name="D26" x="-2.54" y="25.4" visible="pin" length="short"/>
+<pin name="D27" x="-2.54" y="22.86" visible="pin" length="short"/>
+<pin name="D28" x="-2.54" y="20.32" visible="pin" length="short"/>
+<pin name="D29" x="-2.54" y="17.78" visible="pin" length="short"/>
+<pin name="D30" x="-2.54" y="15.24" visible="pin" length="short"/>
+<pin name="A12" x="-2.54" y="12.7" visible="pin" length="short"/>
+<pin name="A13" x="-2.54" y="10.16" visible="pin" length="short"/>
+<pin name="A14" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
+<pin name="A15" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
+<pin name="A16" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
+<pin name="A17" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
+<pin name="A18" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
+<pin name="A19" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
+<pin name="A20" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
+<pin name="A21" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
+<pin name="A22" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
+<pin name="GND3" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
+<pin name="VBAT" x="5.08" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="3.3V2" x="7.62" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="GND2" x="10.16" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="PRGM" x="12.7" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="RST" x="15.24" y="-2.54" visible="pin" length="short" rot="R90"/>
+</symbol>
+<symbol name="TEENSY_3.5_SIMPLE">
+<pin name="D0(RX1)" x="-2.54" y="66.04" visible="pin" length="short"/>
+<pin name="D1(TX1)" x="-2.54" y="63.5" visible="pin" length="short"/>
+<pin name="GND" x="-2.54" y="68.58" visible="pin" length="short"/>
+<wire x1="0" y1="71.12" x2="0" y2="5.08" width="0.254" layer="94"/>
+<wire x1="0" y1="5.08" x2="20.32" y2="5.08" width="0.254" layer="94"/>
+<wire x1="20.32" y1="5.08" x2="20.32" y2="71.12" width="0.254" layer="94"/>
+<wire x1="20.32" y1="71.12" x2="0" y2="71.12" width="0.254" layer="94"/>
+<pin name="D2" x="-2.54" y="60.96" visible="pin" length="short"/>
+<pin name="D3(CANTX)" x="-2.54" y="58.42" visible="pin" length="short"/>
+<pin name="D4(CANRX)" x="-2.54" y="55.88" visible="pin" length="short"/>
+<pin name="D5" x="-2.54" y="53.34" visible="pin" length="short"/>
+<pin name="D6" x="-2.54" y="50.8" visible="pin" length="short"/>
+<pin name="D7(RX3)" x="-2.54" y="48.26" visible="pin" length="short"/>
+<pin name="D8(TX3)" x="-2.54" y="45.72" visible="pin" length="short"/>
+<pin name="D9(RX2)" x="-2.54" y="43.18" visible="pin" length="short"/>
+<pin name="D10(TX2)" x="-2.54" y="40.64" visible="pin" length="short"/>
+<pin name="D11" x="-2.54" y="38.1" visible="pin" length="short"/>
+<pin name="D12" x="-2.54" y="35.56" visible="pin" length="short"/>
+<pin name="D13" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
+<pin name="A0" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
+<pin name="A1" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
+<pin name="A2" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
+<pin name="A3" x="22.86" y="45.72" visible="pin" length="short" rot="R180"/>
+<pin name="A4" x="22.86" y="48.26" visible="pin" length="short" rot="R180"/>
+<pin name="A6" x="22.86" y="53.34" visible="pin" length="short" rot="R180"/>
+<pin name="A5" x="22.86" y="50.8" visible="pin" length="short" rot="R180"/>
+<pin name="A7" x="22.86" y="55.88" visible="pin" length="short" rot="R180"/>
+<pin name="A9" x="22.86" y="60.96" visible="pin" length="short" rot="R180"/>
+<pin name="A8" x="22.86" y="58.42" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V2" x="22.86" y="63.5" visible="pin" length="short" rot="R180"/>
+<pin name="VIN" x="22.86" y="68.58" visible="pin" length="short" rot="R180"/>
+<pin name="AGND" x="22.86" y="66.04" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V" x="-2.54" y="33.02" visible="pin" length="short"/>
+<pin name="D24" x="-2.54" y="30.48" visible="pin" length="short"/>
+<pin name="D25" x="-2.54" y="27.94" visible="pin" length="short"/>
+<pin name="D26" x="-2.54" y="25.4" visible="pin" length="short"/>
+<pin name="D27" x="-2.54" y="22.86" visible="pin" length="short"/>
+<pin name="D28" x="-2.54" y="20.32" visible="pin" length="short"/>
+<pin name="D29" x="-2.54" y="17.78" visible="pin" length="short"/>
+<pin name="D30" x="-2.54" y="15.24" visible="pin" length="short"/>
+<pin name="A12" x="-2.54" y="12.7" visible="pin" length="short"/>
+<pin name="A13" x="-2.54" y="10.16" visible="pin" length="short"/>
+<pin name="A14" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
+<pin name="A15" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
+<pin name="A16" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
+<pin name="A17" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
+<pin name="A18" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
+<pin name="A19" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
+<pin name="A20" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
+<pin name="A21" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
+<pin name="A22" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
+<pin name="GND2" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
+<text x="10.31875" y="6.35" size="1.778" layer="95" align="bottom-center">Teensy 3.5</text>
+</symbol>
+<symbol name="TEENSY_3.2_EXT_12ANALOG">
+<pin name="D0(RX1)" x="-2.54" y="35.56" visible="pin" length="short"/>
+<pin name="D1(TX1)" x="-2.54" y="33.02" visible="pin" length="short"/>
+<pin name="GND" x="-2.54" y="38.1" visible="pin" length="short"/>
+<wire x1="0" y1="40.64" x2="0" y2="-2.54" width="0.254" layer="94"/>
+<wire x1="0" y1="-2.54" x2="20.32" y2="-2.54" width="0.254" layer="94"/>
+<wire x1="20.32" y1="-2.54" x2="20.32" y2="40.64" width="0.254" layer="94"/>
+<wire x1="20.32" y1="40.64" x2="0" y2="40.64" width="0.254" layer="94"/>
+<text x="10.31875" y="-1.27" size="1.778" layer="95" align="bottom-center">Teensy 3.2</text>
+<pin name="D2" x="-2.54" y="30.48" visible="pin" length="short"/>
+<pin name="D3(CANTX)" x="-2.54" y="27.94" visible="pin" length="short"/>
+<pin name="D4(CANRX)" x="-2.54" y="25.4" visible="pin" length="short"/>
+<pin name="D5" x="-2.54" y="22.86" visible="pin" length="short"/>
+<pin name="D6" x="-2.54" y="20.32" visible="pin" length="short"/>
+<pin name="D7(RX3)" x="-2.54" y="17.78" visible="pin" length="short"/>
+<pin name="D8(TX3)" x="-2.54" y="15.24" visible="pin" length="short"/>
+<pin name="D9(RX2)" x="-2.54" y="12.7" visible="pin" length="short"/>
+<pin name="D10(TX2)" x="-2.54" y="10.16" visible="pin" length="short"/>
+<pin name="D11" x="-2.54" y="7.62" visible="pin" length="short"/>
+<pin name="D12" x="-2.54" y="5.08" visible="pin" length="short"/>
+<pin name="D13" x="-2.54" y="2.54" visible="pin" length="short"/>
+<pin name="A0" x="22.86" y="2.54" visible="pin" length="short" rot="R180"/>
+<pin name="A1" x="22.86" y="5.08" visible="pin" length="short" rot="R180"/>
+<pin name="A2" x="22.86" y="7.62" visible="pin" length="short" rot="R180"/>
+<pin name="A3" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
+<pin name="A4" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
+<pin name="A6" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
+<pin name="A5" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
+<pin name="A7" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
+<pin name="A9" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
+<pin name="A8" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
+<pin name="VIN" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
+<pin name="AGND" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
+<pin name="A10" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
+<pin name="A11" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
+</symbol>
 <symbol name="LTC6082">
 <text x="-32.385" y="24.765" size="1.778" layer="95">&gt;NAME</text>
 <text x="-32.385" y="21.59" size="1.778" layer="96">&gt;VALUE</text>
@@ -15717,6 +15967,104 @@ Demo Board</text>
 <pin name="-IND" x="-15.24" y="15.24" visible="pad" length="middle" rot="R180"/>
 <pin name="OUTD" x="-15.24" y="17.78" visible="pad" length="middle" rot="R180"/>
 </symbol>
+<symbol name="TEENSY_3.5_EXT_RTC">
+<pin name="D0(RX1)" x="-2.54" y="66.04" visible="pin" length="short"/>
+<pin name="D1(TX1)" x="-2.54" y="63.5" visible="pin" length="short"/>
+<pin name="GND" x="-2.54" y="68.58" visible="pin" length="short"/>
+<wire x1="0" y1="73.66" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
+<wire x1="20.32" y1="0" x2="20.32" y2="73.66" width="0.254" layer="94"/>
+<wire x1="20.32" y1="73.66" x2="0" y2="73.66" width="0.254" layer="94"/>
+<text x="10.31875" y="70.866" size="1.778" layer="95" align="bottom-center">Teensy 3.5</text>
+<pin name="D2" x="-2.54" y="60.96" visible="pin" length="short"/>
+<pin name="D3(CANTX)" x="-2.54" y="58.42" visible="pin" length="short"/>
+<pin name="D4(CANRX)" x="-2.54" y="55.88" visible="pin" length="short"/>
+<pin name="D5" x="-2.54" y="53.34" visible="pin" length="short"/>
+<pin name="D6" x="-2.54" y="50.8" visible="pin" length="short"/>
+<pin name="D7(RX3)" x="-2.54" y="48.26" visible="pin" length="short"/>
+<pin name="D8(TX3)" x="-2.54" y="45.72" visible="pin" length="short"/>
+<pin name="D9(RX2)" x="-2.54" y="43.18" visible="pin" length="short"/>
+<pin name="D10(TX2)" x="-2.54" y="40.64" visible="pin" length="short"/>
+<pin name="D11" x="-2.54" y="38.1" visible="pin" length="short"/>
+<pin name="D12" x="-2.54" y="35.56" visible="pin" length="short"/>
+<pin name="D13" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
+<pin name="A0" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
+<pin name="A1" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
+<pin name="A2" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
+<pin name="A3" x="22.86" y="45.72" visible="pin" length="short" rot="R180"/>
+<pin name="A4" x="22.86" y="48.26" visible="pin" length="short" rot="R180"/>
+<pin name="A6" x="22.86" y="53.34" visible="pin" length="short" rot="R180"/>
+<pin name="A5" x="22.86" y="50.8" visible="pin" length="short" rot="R180"/>
+<pin name="A7" x="22.86" y="55.88" visible="pin" length="short" rot="R180"/>
+<pin name="A9" x="22.86" y="60.96" visible="pin" length="short" rot="R180"/>
+<pin name="A8" x="22.86" y="58.42" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V3" x="22.86" y="63.5" visible="pin" length="short" rot="R180"/>
+<pin name="VIN" x="22.86" y="68.58" visible="pin" length="short" rot="R180"/>
+<pin name="AGND" x="22.86" y="66.04" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V" x="-2.54" y="33.02" visible="pin" length="short"/>
+<pin name="D24" x="-2.54" y="30.48" visible="pin" length="short"/>
+<pin name="D25" x="-2.54" y="27.94" visible="pin" length="short"/>
+<pin name="D26" x="-2.54" y="25.4" visible="pin" length="short"/>
+<pin name="D27" x="-2.54" y="22.86" visible="pin" length="short"/>
+<pin name="D28" x="-2.54" y="20.32" visible="pin" length="short"/>
+<pin name="D29" x="-2.54" y="17.78" visible="pin" length="short"/>
+<pin name="D30" x="-2.54" y="15.24" visible="pin" length="short"/>
+<pin name="A12" x="-2.54" y="12.7" visible="pin" length="short"/>
+<pin name="A13" x="-2.54" y="10.16" visible="pin" length="short"/>
+<pin name="A14" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
+<pin name="A15" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
+<pin name="A16" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
+<pin name="A17" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
+<pin name="A18" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
+<pin name="A19" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
+<pin name="A20" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
+<pin name="A21" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
+<pin name="A22" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
+<pin name="GND3" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
+<pin name="VBAT" x="5.08" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="3.3V2" x="7.62" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="GND2" x="10.16" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="PRGM" x="12.7" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="RST" x="15.24" y="-2.54" visible="pin" length="short" rot="R90"/>
+</symbol>
+<symbol name="PCC-SMP-K-100-R-ROHS">
+<wire x1="5.08" y1="2.54" x2="15.24" y2="2.54" width="0.254" layer="94"/>
+<wire x1="15.24" y1="-2.54" x2="15.24" y2="2.54" width="0.254" layer="94"/>
+<wire x1="15.24" y1="-2.54" x2="5.08" y2="-2.54" width="0.254" layer="94"/>
+<wire x1="5.08" y1="2.54" x2="5.08" y2="-2.54" width="0.254" layer="94"/>
+<text x="16.51" y="7.62" size="1.778" layer="95" align="center-left">&gt;NAME</text>
+<text x="16.51" y="5.08" size="1.778" layer="96" align="center-left">&gt;VALUE</text>
+<pin name="+" x="0" y="0" length="middle"/>
+<pin name="-" x="20.32" y="0" length="middle" rot="R180"/>
+</symbol>
+<symbol name="LTC6081IMS8PBF">
+<pin name="OUTA" x="2.54" y="0" length="middle" direction="out"/>
+<pin name="-INA" x="2.54" y="-2.54" length="middle" direction="in"/>
+<pin name="+INA" x="2.54" y="-5.08" length="middle" direction="in"/>
+<pin name="V-" x="2.54" y="-7.62" length="middle" direction="pwr"/>
+<pin name="+INB" x="58.42" y="-7.62" length="middle" direction="in" rot="R180"/>
+<pin name="-INB" x="58.42" y="-5.08" length="middle" direction="in" rot="R180"/>
+<pin name="OUTB" x="58.42" y="-2.54" length="middle" direction="out" rot="R180"/>
+<pin name="V+" x="58.42" y="0" length="middle" direction="pwr" rot="R180"/>
+<wire x1="7.62" y1="5.08" x2="7.62" y2="-12.7" width="0.1524" layer="94"/>
+<wire x1="7.62" y1="-12.7" x2="53.34" y2="-12.7" width="0.1524" layer="94"/>
+<wire x1="53.34" y1="-12.7" x2="53.34" y2="5.08" width="0.1524" layer="94"/>
+<wire x1="53.34" y1="5.08" x2="7.62" y2="5.08" width="0.1524" layer="94"/>
+<text x="25.7556" y="9.1186" size="2.0828" layer="95" ratio="6" rot="SR0">&gt;Name</text>
+<text x="25.1206" y="6.5786" size="2.0828" layer="96" ratio="6" rot="SR0">&gt;Value</text>
+</symbol>
+<symbol name="ACHS-7121">
+<wire x1="0" y1="0" x2="17.78" y2="0" width="0.254" layer="94"/>
+<wire x1="17.78" y1="0" x2="17.78" y2="20.32" width="0.254" layer="94"/>
+<wire x1="17.78" y1="20.32" x2="0" y2="20.32" width="0.254" layer="94"/>
+<wire x1="0" y1="20.32" x2="0" y2="0" width="0.254" layer="94"/>
+<pin name="IP+" x="-5.08" y="15.24" length="middle"/>
+<pin name="IP-" x="-5.08" y="7.62" length="middle"/>
+<pin name="VOUT" x="22.86" y="12.7" length="middle" rot="R180"/>
+<pin name="VDD" x="22.86" y="17.78" length="middle" rot="R180"/>
+<pin name="FILTER" x="22.86" y="7.62" length="middle" rot="R180"/>
+<pin name="GND" x="22.86" y="2.54" length="middle" rot="R180"/>
+</symbol>
 <symbol name="10118192-0001LF">
 <wire x1="-5.08" y1="10.16" x2="5.08" y2="10.16" width="0.1524" layer="94"/>
 <wire x1="5.08" y1="10.16" x2="5.08" y2="-10.16" width="0.1524" layer="94"/>
@@ -15730,29 +16078,6 @@ Demo Board</text>
 <pin name="ID" x="-7.62" y="0" length="short" direction="pas"/>
 <pin name="GND" x="-7.62" y="-2.54" length="short" direction="pas"/>
 <pin name="SHIELD" x="-7.62" y="-7.62" length="short" direction="pas"/>
-</symbol>
-<symbol name="MAX4622">
-<description>Maxim Integrated MAX4622 analogue switch.</description>
-<pin name="COM1" x="-5.08" y="-2.54" length="middle"/>
-<pin name="COM3" x="-5.08" y="-7.62" length="middle"/>
-<pin name="NC3" x="-5.08" y="-10.16" length="middle"/>
-<pin name="NC4" x="-5.08" y="-12.7" length="middle"/>
-<pin name="COM4" x="-5.08" y="-15.24" length="middle"/>
-<pin name="COM2" x="-5.08" y="-20.32" length="middle"/>
-<pin name="NO2" x="25.4" y="-20.32" length="middle" rot="R180"/>
-<pin name="IN2" x="25.4" y="-17.78" length="middle" rot="R180"/>
-<pin name="V+" x="25.4" y="-15.24" length="middle" rot="R180"/>
-<pin name="VL" x="25.4" y="-12.7" length="middle" rot="R180"/>
-<pin name="GND" x="25.4" y="-10.16" length="middle" rot="R180"/>
-<pin name="V-" x="25.4" y="-7.62" length="middle" rot="R180"/>
-<pin name="IN1" x="25.4" y="-5.08" length="middle" rot="R180"/>
-<pin name="NO1" x="25.4" y="-2.54" length="middle" rot="R180"/>
-<text x="2.54" y="0" size="1.778" layer="95">&gt;NAME</text>
-<text x="2.54" y="-25.4" size="1.778" layer="95">&gt;VALUE</text>
-<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
-<wire x1="20.32" y1="0" x2="20.32" y2="-22.86" width="0.254" layer="94"/>
-<wire x1="20.32" y1="-22.86" x2="0" y2="-22.86" width="0.254" layer="94"/>
-<wire x1="0" y1="-22.86" x2="0" y2="0" width="0.254" layer="94"/>
 </symbol>
 <symbol name="LED-THERMAL">
 <description>LED
@@ -15781,6 +16106,85 @@ Demo Board</text>
 <vertex x="0" y="-2.54"/>
 </polygon>
 <pin name="X" x="-2.54" y="2.54" visible="off" length="short" direction="pas" rot="R270"/>
+</symbol>
+<symbol name="MAX4622">
+<description>Maxim Integrated MAX4622 analogue switch.</description>
+<pin name="COM1" x="-5.08" y="-2.54" length="middle"/>
+<pin name="COM3" x="-5.08" y="-7.62" length="middle"/>
+<pin name="NC3" x="-5.08" y="-10.16" length="middle"/>
+<pin name="NC4" x="-5.08" y="-12.7" length="middle"/>
+<pin name="COM4" x="-5.08" y="-15.24" length="middle"/>
+<pin name="COM2" x="-5.08" y="-20.32" length="middle"/>
+<pin name="NO2" x="25.4" y="-20.32" length="middle" rot="R180"/>
+<pin name="IN2" x="25.4" y="-17.78" length="middle" rot="R180"/>
+<pin name="V+" x="25.4" y="-15.24" length="middle" rot="R180"/>
+<pin name="VL" x="25.4" y="-12.7" length="middle" rot="R180"/>
+<pin name="GND" x="25.4" y="-10.16" length="middle" rot="R180"/>
+<pin name="V-" x="25.4" y="-7.62" length="middle" rot="R180"/>
+<pin name="IN1" x="25.4" y="-5.08" length="middle" rot="R180"/>
+<pin name="NO1" x="25.4" y="-2.54" length="middle" rot="R180"/>
+<text x="2.54" y="0" size="1.778" layer="95">&gt;NAME</text>
+<text x="2.54" y="-25.4" size="1.778" layer="95">&gt;VALUE</text>
+<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
+<wire x1="20.32" y1="0" x2="20.32" y2="-22.86" width="0.254" layer="94"/>
+<wire x1="20.32" y1="-22.86" x2="0" y2="-22.86" width="0.254" layer="94"/>
+<wire x1="0" y1="-22.86" x2="0" y2="0" width="0.254" layer="94"/>
+</symbol>
+<symbol name="TEENSY_LC_EXT">
+<pin name="D0(RX1)" x="-2.54" y="40.64" visible="pin" length="short"/>
+<pin name="D1(TX1)" x="-2.54" y="38.1" visible="pin" length="short"/>
+<pin name="GND" x="-2.54" y="43.18" visible="pin" length="short"/>
+<wire x1="0" y1="48.26" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
+<wire x1="20.32" y1="0" x2="20.32" y2="48.26" width="0.254" layer="94"/>
+<wire x1="20.32" y1="48.26" x2="0" y2="48.26" width="0.254" layer="94"/>
+<text x="2.54" y="45.72" size="1.778" layer="95">Teensy LC</text>
+<pin name="D2" x="-2.54" y="35.56" visible="pin" length="short"/>
+<pin name="D3" x="-2.54" y="33.02" visible="pin" length="short"/>
+<pin name="D4" x="-2.54" y="30.48" visible="pin" length="short"/>
+<pin name="D5" x="-2.54" y="27.94" visible="pin" length="short"/>
+<pin name="D6" x="-2.54" y="25.4" visible="pin" length="short"/>
+<pin name="D7(RX3)" x="-2.54" y="22.86" visible="pin" length="short"/>
+<pin name="D8(TX3)" x="-2.54" y="20.32" visible="pin" length="short"/>
+<pin name="D9(RX2)" x="-2.54" y="17.78" visible="pin" length="short"/>
+<pin name="D10(TX2)" x="-2.54" y="15.24" visible="pin" length="short"/>
+<pin name="D11" x="-2.54" y="12.7" visible="pin" length="short"/>
+<pin name="D12" x="-2.54" y="10.16" visible="pin" length="short"/>
+<pin name="D13" x="22.86" y="10.16" visible="pin" length="short" rot="R180"/>
+<pin name="A0" x="22.86" y="12.7" visible="pin" length="short" rot="R180"/>
+<pin name="A1" x="22.86" y="15.24" visible="pin" length="short" rot="R180"/>
+<pin name="A2" x="22.86" y="17.78" visible="pin" length="short" rot="R180"/>
+<pin name="A3" x="22.86" y="20.32" visible="pin" length="short" rot="R180"/>
+<pin name="A4" x="22.86" y="22.86" visible="pin" length="short" rot="R180"/>
+<pin name="A6" x="22.86" y="27.94" visible="pin" length="short" rot="R180"/>
+<pin name="A5" x="22.86" y="25.4" visible="pin" length="short" rot="R180"/>
+<pin name="A7" x="22.86" y="30.48" visible="pin" length="short" rot="R180"/>
+<pin name="A9" x="22.86" y="35.56" visible="pin" length="short" rot="R180"/>
+<pin name="A8" x="22.86" y="33.02" visible="pin" length="short" rot="R180"/>
+<pin name="3.3V2" x="22.86" y="38.1" visible="pin" length="short" rot="R180"/>
+<pin name="VIN" x="22.86" y="43.18" visible="pin" length="short" rot="R180"/>
+<pin name="AGND" x="22.86" y="40.64" visible="pin" length="short" rot="R180"/>
+<pin name="D17" x="5.08" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="3.3V" x="7.62" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="GND2" x="10.16" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="PGRM" x="12.7" y="-2.54" visible="pin" length="short" rot="R90"/>
+<pin name="DAC" x="15.24" y="-2.54" visible="pin" length="short" rot="R90"/>
+</symbol>
+<symbol name="MAX31855KASA+">
+<pin name="GND" x="2.54" y="0" length="middle" direction="pwr"/>
+<pin name="T-" x="2.54" y="-2.54" length="middle" direction="in"/>
+<pin name="T+" x="2.54" y="-5.08" length="middle" direction="in"/>
+<pin name="VCC" x="2.54" y="-7.62" length="middle" direction="pwr"/>
+<pin name="SCK" x="27.94" y="-7.62" length="middle" direction="in" rot="R180"/>
+<pin name="!CS" x="27.94" y="-5.08" length="middle" direction="pas" rot="R180"/>
+<pin name="SO" x="27.94" y="-2.54" length="middle" direction="out" rot="R180"/>
+<pin name="DNC" x="27.94" y="0" length="middle" direction="nc" rot="R180"/>
+<wire x1="7.62" y1="2.54" x2="7.62" y2="-10.16" width="0.1524" layer="94"/>
+<wire x1="7.62" y1="-10.16" x2="22.86" y2="-10.16" width="0.1524" layer="94"/>
+<wire x1="22.86" y1="-10.16" x2="22.86" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="22.86" y1="2.54" x2="7.62" y2="2.54" width="0.1524" layer="94"/>
+<text x="10.5156" y="6.5786" size="2.0828" layer="95" ratio="6" rot="SR0">&gt;Name</text>
+<text x="9.8806" y="4.0386" size="2.0828" layer="96" ratio="6" rot="SR0">&gt;Value</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -18561,186 +18965,6 @@ It is replaced by MCP2561.
 </device>
 </devices>
 </deviceset>
-<deviceset name="RESISTOR" prefix="R" uservalue="yes">
-<description>&lt;b&gt;Resistor&lt;/b&gt;
-Basic schematic elements and footprints for 0603, 1206, and PTH resistors.</description>
-<gates>
-<gate name="G$1" symbol="RESISTOR" x="0" y="0"/>
-</gates>
-<devices>
-<device name="0402" package="0402-RES">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="0603" package="0603-RES">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="0603-RES" package="0603-RES">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="0805-RES" package="0805">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="1206" package="1206">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="2010" package="R2010">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="2512" package="R2512">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="AXIAL-0.3" package="AXIAL-0.3">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="EZ" package="AXIAL-0.3EZ">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="KIT" package="AXIAL-0.3-KIT">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="PTH-1/2W" package="AXIAL-0.5">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="PTH-1/4W" package="AXIAL-0.4">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="PTH-1/4W-VERT" package="AXIAL-0.1">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="PTH-1/4W-VERT-KIT" package="AXIAL-0.1EZ">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="PTH-1/6W" package="1/6W-RES">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="PTH-1W" package="AXIAL-0.6">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="PTH-2W" package="AXIAL-0.8">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="10W" package="10W_RESISTOR_VISHAY">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="PWR163" package="PWR163">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
 <deviceset name="CAP" prefix="C" uservalue="yes">
 <description>&lt;b&gt;Capacitor&lt;/b&gt;
 Standard 0603 ceramic capacitor, and 0.1" leaded capacitor.</description>
@@ -19091,7 +19315,7 @@ Standard 0603 ceramic capacitor, and 0.1" leaded capacitor.</description>
 </devices>
 </deviceset>
 <deviceset name="TEENSY_3.2_SIMPLE">
-<description>Simple version of the Teensy 3.2 board that only uses the 2 main rows of pins, with no perpendicular row with VBat or inner pins.</description>
+<description>Simple version of the Teensy 3.2 board that only uses the 2 main rows of pins, not the inner pins or the pins opposite the usb port.</description>
 <gates>
 <gate name="G$1" symbol="TEENSY_3.2_SIMPLE" x="0" y="0"/>
 </gates>
@@ -19287,68 +19511,6 @@ MAX voltage in: 35V</description>
 <connect gate="G$1" pin="VCC2" pad="3"/>
 <connect gate="G$1" pin="VCC3" pad="5"/>
 <connect gate="G$1" pin="VCC4" pad="7"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="LTC6804-1" uservalue="yes">
-<gates>
-<gate name="G$1" symbol="LTC6804-1" x="-27.94" y="5.08"/>
-</gates>
-<devices>
-<device name="" package="LTC6804">
-<connects>
-<connect gate="G$1" pin="C0" pad="26"/>
-<connect gate="G$1" pin="C1" pad="24"/>
-<connect gate="G$1" pin="C10" pad="6"/>
-<connect gate="G$1" pin="C11" pad="4"/>
-<connect gate="G$1" pin="C12" pad="2"/>
-<connect gate="G$1" pin="C2" pad="22"/>
-<connect gate="G$1" pin="C3" pad="20"/>
-<connect gate="G$1" pin="C4" pad="18"/>
-<connect gate="G$1" pin="C5" pad="16"/>
-<connect gate="G$1" pin="C6" pad="14"/>
-<connect gate="G$1" pin="C7" pad="12"/>
-<connect gate="G$1" pin="C8" pad="10"/>
-<connect gate="G$1" pin="C9" pad="8"/>
-<connect gate="G$1" pin="CSB(IMA)" pad="41"/>
-<connect gate="G$1" pin="DRIVE" pad="38"/>
-<connect gate="G$1" pin="GPI01" pad="27"/>
-<connect gate="G$1" pin="GPI02" pad="28"/>
-<connect gate="G$1" pin="GPI03" pad="29"/>
-<connect gate="G$1" pin="GPI04" pad="32"/>
-<connect gate="G$1" pin="GPI05" pad="33"/>
-<connect gate="G$1" pin="IBIAS" pad="45"/>
-<connect gate="G$1" pin="ICMP" pad="46"/>
-<connect gate="G$1" pin="IMB" pad="47"/>
-<connect gate="G$1" pin="IPB" pad="48"/>
-<connect gate="G$1" pin="ISOMD" pad="40"/>
-<connect gate="G$1" pin="S1" pad="25"/>
-<connect gate="G$1" pin="S10" pad="7"/>
-<connect gate="G$1" pin="S11" pad="5"/>
-<connect gate="G$1" pin="S12" pad="3"/>
-<connect gate="G$1" pin="S2" pad="23"/>
-<connect gate="G$1" pin="S3" pad="21"/>
-<connect gate="G$1" pin="S4" pad="19"/>
-<connect gate="G$1" pin="S5" pad="17"/>
-<connect gate="G$1" pin="S6" pad="15"/>
-<connect gate="G$1" pin="S7" pad="13"/>
-<connect gate="G$1" pin="S8" pad="11"/>
-<connect gate="G$1" pin="S9" pad="9"/>
-<connect gate="G$1" pin="SCK(IPA)" pad="42"/>
-<connect gate="G$1" pin="SDI(NC)" pad="43"/>
-<connect gate="G$1" pin="SDO(NC)" pad="44"/>
-<connect gate="G$1" pin="SWTEN" pad="36"/>
-<connect gate="G$1" pin="V+" pad="1"/>
-<connect gate="G$1" pin="V-" pad="31"/>
-<connect gate="G$1" pin="V-**" pad="30"/>
-<connect gate="G$1" pin="VREF1" pad="35"/>
-<connect gate="G$1" pin="VREF2" pad="34"/>
-<connect gate="G$1" pin="VREG" pad="37"/>
-<connect gate="G$1" pin="WDT" pad="39"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -20482,17 +20644,17 @@ Source: Adafruit</description>
 </device>
 </devices>
 </deviceset>
-<deviceset name="TEENSY_3.5_EXT_RTC">
-<description>Extended version of the Teensy 3.5 board that only uses the 2 main rows of pins, plus the perpendicular row with VBat.</description>
+<deviceset name="TEENSY_3.5_EXT">
+<description>Simple version of the Teensy 3.5 board that only uses the 2 main rows of pins, plus the perpendicular row with VBat.</description>
 <gates>
-<gate name="G$1" symbol="TEENSY_3.5_EXT_RTC" x="0" y="0"/>
+<gate name="G$1" symbol="TEENSY_3.5_SIMPLE_RTC" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TEENSY_3.5_EXT_RTC">
+<device name="" package="TEENSY_3.5_EXT">
 <connects>
 <connect gate="G$1" pin="3.3V" pad="3.3V"/>
-<connect gate="G$1" pin="3.3V2" pad="3.3V2"/>
-<connect gate="G$1" pin="3.3V3" pad="3.3V3"/>
+<connect gate="G$1" pin="3.3V_1" pad="3.3V_1"/>
+<connect gate="G$1" pin="3.3V_2" pad="3.3V_2"/>
 <connect gate="G$1" pin="A0" pad="A0"/>
 <connect gate="G$1" pin="A1" pad="A1"/>
 <connect gate="G$1" pin="A12" pad="A12"/>
@@ -20537,9 +20699,9 @@ Source: Adafruit</description>
 <connect gate="G$1" pin="D8(TX3)" pad="D8(TX3)"/>
 <connect gate="G$1" pin="D9(RX2)" pad="D9(RX2)"/>
 <connect gate="G$1" pin="GND" pad="GND"/>
-<connect gate="G$1" pin="GND2" pad="GND2"/>
-<connect gate="G$1" pin="GND3" pad="GND3"/>
-<connect gate="G$1" pin="PRGM" pad="PRGM"/>
+<connect gate="G$1" pin="GND_1" pad="GND_1"/>
+<connect gate="G$1" pin="GND_2" pad="GND_2"/>
+<connect gate="G$1" pin="PROG" pad="PROG"/>
 <connect gate="G$1" pin="RST" pad="RST"/>
 <connect gate="G$1" pin="VBAT" pad="VBAT"/>
 <connect gate="G$1" pin="VIN" pad="VIN"/>
@@ -20671,32 +20833,6 @@ Use with 0.47µF input capacitor and 33µF output capacitor.</description>
 <connect gate="G$1" pin="VOUTA" pad="1"/>
 <connect gate="G$1" pin="VOUTB" pad="7"/>
 <connect gate="G$1" pin="VSS" pad="4"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="BATTERY_SPRING">
-<description>&lt;b&gt; Keystone Electronics Battery Spring Contact &lt;/b&gt;
-&lt;br&gt;
-&lt;a href="http://keyelco.com/userAssets/file/M65p17.pdf"&gt;Datasheet&lt;/a&gt;</description>
-<gates>
-<gate name="G$1" symbol="MV" x="0" y="0" addlevel="always"/>
-</gates>
-<devices>
-<device name="_KEYSTONE5222" package="KEYSTONE5222">
-<connects>
-<connect gate="G$1" pin="S" pad="P$1"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="" package="KEYSTONE5203">
-<connects>
-<connect gate="G$1" pin="S" pad="P$1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -21053,15 +21189,6 @@ Littelfuse 1812L Series Surface Mount PTC (resettable) Fuse
 <technology name=""/>
 </technologies>
 </device>
-<device name="0603" package="0603-RES">
-<connects>
-<connect gate="G$1" pin="P$1" pad="1"/>
-<connect gate="G$1" pin="P$2" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
 </devices>
 </deviceset>
 <deviceset name="DC1894B">
@@ -21326,18 +21453,20 @@ Note: The Sparkfun version includes many other packages including surface mount 
 </device>
 </devices>
 </deviceset>
-<deviceset name="TEENSY_LC_EXT">
-<description>Extended version of the Teensy LC board that only uses the 2 main rows of pins, plus the perpendicular row with VBat.</description>
+<deviceset name="TEENSY_LC">
+<description>Version of the Teensy LC board that uses the 2 main rows of pins and the pins opposite the usb port.</description>
 <gates>
-<gate name="G$1" symbol="TEENSY_LC_EXT" x="0" y="0"/>
+<gate name="G$1" symbol="TEENSY_LC" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TEENSY_LC_EXT">
+<device name="" package="TEENSY_LC">
 <connects>
+<connect gate="G$1" pin="17VIN" pad="17VIN"/>
 <connect gate="G$1" pin="3.3V" pad="3.3V"/>
 <connect gate="G$1" pin="3.3V2" pad="3.3V2"/>
 <connect gate="G$1" pin="A0" pad="A0"/>
 <connect gate="G$1" pin="A1" pad="A1"/>
+<connect gate="G$1" pin="A12" pad="A12"/>
 <connect gate="G$1" pin="A2" pad="A2"/>
 <connect gate="G$1" pin="A3" pad="A3"/>
 <connect gate="G$1" pin="A4" pad="A4"/>
@@ -21353,16 +21482,14 @@ Note: The Sparkfun version includes many other packages including surface mount 
 <connect gate="G$1" pin="D11" pad="D11"/>
 <connect gate="G$1" pin="D12" pad="D12"/>
 <connect gate="G$1" pin="D13" pad="D13"/>
-<connect gate="G$1" pin="D17" pad="D17"/>
 <connect gate="G$1" pin="D2" pad="D2"/>
-<connect gate="G$1" pin="D3" pad="D3"/>
-<connect gate="G$1" pin="D4" pad="D4"/>
-<connect gate="G$1" pin="D5" pad="D5"/>
-<connect gate="G$1" pin="D6" pad="D6"/>
+<connect gate="G$1" pin="D3(RX1)" pad="D3(RX1)"/>
+<connect gate="G$1" pin="D4(TX1)" pad="D4(TX1)"/>
+<connect gate="G$1" pin="D5(TX1)" pad="D5(TX1)"/>
+<connect gate="G$1" pin="D6(RX3)" pad="D6(RX3)"/>
 <connect gate="G$1" pin="D7(RX3)" pad="D7(RX3)"/>
 <connect gate="G$1" pin="D8(TX3)" pad="D8(TX3)"/>
 <connect gate="G$1" pin="D9(RX2)" pad="D9(RX2)"/>
-<connect gate="G$1" pin="DAC" pad="DAC"/>
 <connect gate="G$1" pin="GND" pad="GND"/>
 <connect gate="G$1" pin="GND2" pad="GND2"/>
 <connect gate="G$1" pin="PGRM" pad="PGRM"/>
@@ -21795,33 +21922,6 @@ Note: The Sparkfun version includes many other packages including surface mount 
 <technology name="">
 <attribute name="__EXTERNAL__" value="" constant="no"/>
 </technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="0001.2704.11">
-<description>&lt;b&gt; Schurter Surface Mount Ceramic Fuse &lt;/b&gt;
-&lt;br&gt;
-Current Rating: 1A
-&lt;br&gt;
-Voltage Rating AC: 250 VAC
-&lt;br&gt;
-Voltage Rating DC: 300 VDC
-&lt;br&gt;
-Dimensions: 5 mm x 20 mm
-&lt;br&gt;
-&lt;a href="http://www.mouser.com/ds/2/358/typ_SMD-SPT-46594.pdf"&gt;Datasheet&lt;/a&gt;</description>
-<gates>
-<gate name="G$1" symbol="FUSE" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="5X20MM_FUSE">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<technologies>
-<technology name=""/>
 </technologies>
 </device>
 </devices>
@@ -22340,7 +22440,7 @@ Output Current: 50 mA (max)
 </devices>
 </deviceset>
 <deviceset name="TEENSY_3.2_EXT">
-<description>Extended version of the Teensy 3.2 board that only uses the 2 main rows of pins, plus the perpendicular row with VBat.</description>
+<description>Version of the Teensy LC board that uses the 2 main rows of pins and the pins opposite the usb port.</description>
 <gates>
 <gate name="G$1" symbol="TEENSY_3.2_EXT" x="0" y="0"/>
 </gates>
@@ -22582,13 +22682,12 @@ MAX voltage: 100V</description>
 </device>
 </devices>
 </deviceset>
-<deviceset name="TEENSY_3.2_EXT_12ANALOG">
-<description>Simple version of the Teensy 3.2 board that only uses the 2 main rows of pins, with 12 Analog pins and no perpendicular row with VBat or inner pins.</description>
+<deviceset name="TEENSY_3.2_12ANALOG">
 <gates>
-<gate name="G$1" symbol="TEENSY_3.2_EXT_12ANALOG" x="0" y="0"/>
+<gate name="G$1" symbol="TEENSY_3.2_12ANALOG" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TEENSY_3.2_EXT_12ANALOG">
+<device name="" package="TEENSY_3.2_12ANALOG">
 <connects>
 <connect gate="G$1" pin="3.3V" pad="3.3V"/>
 <connect gate="G$1" pin="A0" pad="A0"/>
@@ -22893,8 +22992,8 @@ Standard character type LCDs, available in sizes from 8x1 to 40x4!</description>
 <connect gate="G$1" pin="GND" pad="5"/>
 <connect gate="G$1" pin="IP+" pad="1 2"/>
 <connect gate="G$1" pin="IP-" pad="3 4"/>
-<connect gate="G$1" pin="VDD" pad="8"/>
-<connect gate="G$1" pin="VOUT" pad="7"/>
+<connect gate="G$1" pin="VCC" pad="8"/>
+<connect gate="G$1" pin="VIOUT" pad="7"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -23212,7 +23311,7 @@ Leakage Inductance: 0.50 uH max
 <deviceset name="L01Z150S05">
 <description>Tamura Hall Effect Current Sensors L01Z***S05 Series
 &lt;br&gt;
-&lt;br&gt; Refer to
+&lt;br&gt; Refer to 
 &lt;a href="http://www.tamuracorp.com/clientuploads/pdfs/engineeringdocs/L01ZXXXS05.pdf "&gt;datasheet &lt;/a&gt;</description>
 <gates>
 <gate name="G$1" symbol="L01Z150S05" x="0" y="0"/>
@@ -23501,6 +23600,202 @@ DMG3406L (SOT-23, 2.8 A 30V)&lt;br&gt;</description>
 </device>
 </devices>
 </deviceset>
+<deviceset name="JUMPER_SWITCH_2" prefix="J">
+<description>Jumper Switch: Switch between 2 circuits by cutting default trace and soldering pads together.</description>
+<gates>
+<gate name="G$1" symbol="JUMPER_SWITCH_2" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="JUMPER_SWITCH_2">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+<connect gate="G$1" pin="P$2" pad="P$2"/>
+<connect gate="G$1" pin="P$3" pad="P$3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="JUMPER_SWITCH_1" prefix="J">
+<description>Jumper Switch: Switch a circuit by cutting trace or soldering pads back together.</description>
+<gates>
+<gate name="G$1" symbol="JUMPER_SWITCH_1" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="JUMPER_SWITCH_1">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+<connect gate="G$1" pin="P$2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="DMG2305UX">
+<description>P-CHANNEL ENHANCEMENT MODE MOSFET</description>
+<gates>
+<gate name="G$1" symbol="P-CHANNEL_MOSFET" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="SOT23">
+<connects>
+<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="G" pad="1"/>
+<connect gate="G$1" pin="S" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="DMMT5401">
+<gates>
+<gate name="G$1" symbol="PNP_BJT" x="-10.16" y="0"/>
+<gate name="G$2" symbol="PNP_BJT" x="10.16" y="0"/>
+</gates>
+<devices>
+<device name="" package="SOT26">
+<connects>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="6"/>
+<connect gate="G$2" pin="B" pad="3"/>
+<connect gate="G$2" pin="C" pad="4"/>
+<connect gate="G$2" pin="E" pad="5"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="CRYSTAL_GROUNDED">
+<gates>
+<gate name="G$1" symbol="Q-SHIELD2" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_3.2X2.5MM" package="CRYSTAL_3.2X2.5MM">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+<connect gate="G$1" pin="3" pad="P$3"/>
+<connect gate="G$1" pin="4" pad="P$4"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="LTC6811-2">
+<description>&lt;b&gt; Linear Technology Multicell Battery Stack Monitor &lt;/b&gt;
+&lt;br&gt;
+Variant 2: Addressable/Multi-Drop Configuration
+&lt;br&gt;
+&lt;a href="http://cds.linear.com/docs/en/datasheet/680412fc.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<gates>
+<gate name="G$1" symbol="LTC6804-2" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="LTC6811">
+<connects>
+<connect gate="G$1" pin="A0" pad="45"/>
+<connect gate="G$1" pin="A1" pad="46"/>
+<connect gate="G$1" pin="A2" pad="47"/>
+<connect gate="G$1" pin="A3" pad="48"/>
+<connect gate="G$1" pin="C0" pad="26"/>
+<connect gate="G$1" pin="C1" pad="24"/>
+<connect gate="G$1" pin="C10" pad="6"/>
+<connect gate="G$1" pin="C11" pad="4"/>
+<connect gate="G$1" pin="C12" pad="2"/>
+<connect gate="G$1" pin="C2" pad="22"/>
+<connect gate="G$1" pin="C3" pad="20"/>
+<connect gate="G$1" pin="C4" pad="18"/>
+<connect gate="G$1" pin="C5" pad="16"/>
+<connect gate="G$1" pin="C6" pad="14"/>
+<connect gate="G$1" pin="C7" pad="12"/>
+<connect gate="G$1" pin="C8" pad="10"/>
+<connect gate="G$1" pin="C9" pad="8"/>
+<connect gate="G$1" pin="CSB(IMA)" pad="41"/>
+<connect gate="G$1" pin="DRIVE" pad="38"/>
+<connect gate="G$1" pin="GPI01" pad="27"/>
+<connect gate="G$1" pin="GPI02" pad="28"/>
+<connect gate="G$1" pin="GPI03" pad="29"/>
+<connect gate="G$1" pin="GPI04" pad="32"/>
+<connect gate="G$1" pin="GPI05" pad="33"/>
+<connect gate="G$1" pin="ISOMD" pad="40"/>
+<connect gate="G$1" pin="S1" pad="25"/>
+<connect gate="G$1" pin="S10" pad="7"/>
+<connect gate="G$1" pin="S11" pad="5"/>
+<connect gate="G$1" pin="S12" pad="3"/>
+<connect gate="G$1" pin="S2" pad="23"/>
+<connect gate="G$1" pin="S3" pad="21"/>
+<connect gate="G$1" pin="S4" pad="19"/>
+<connect gate="G$1" pin="S5" pad="17"/>
+<connect gate="G$1" pin="S6" pad="15"/>
+<connect gate="G$1" pin="S7" pad="13"/>
+<connect gate="G$1" pin="S8" pad="11"/>
+<connect gate="G$1" pin="S9" pad="9"/>
+<connect gate="G$1" pin="SCK(IPA)" pad="42"/>
+<connect gate="G$1" pin="SDI(ICMP)" pad="43"/>
+<connect gate="G$1" pin="SDO(IBIAS)" pad="44"/>
+<connect gate="G$1" pin="SWTEN" pad="36"/>
+<connect gate="G$1" pin="V+" pad="1"/>
+<connect gate="G$1" pin="V-" pad="31"/>
+<connect gate="G$1" pin="V-**" pad="30"/>
+<connect gate="G$1" pin="VREF1" pad="35"/>
+<connect gate="G$1" pin="VREF2" pad="34"/>
+<connect gate="G$1" pin="VREG" pad="37"/>
+<connect gate="G$1" pin="WDT" pad="39"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="OKI-78SR-3.3">
+<description>Murata OKI-78SR 5V 1.5A Non-Isolated Switching Regulator DC/DC - &lt;a href="https://power.murata.com/data/power/oki-78sr.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<gates>
+<gate name="G$1" symbol="VOLTAGE_REGULATOR" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="OKI-78SR">
+<connects>
+<connect gate="G$1" pin="GND" pad="2"/>
+<connect gate="G$1" pin="IN" pad="1"/>
+<connect gate="G$1" pin="OUT" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="XP-E2">
+<description>XP-E2 high-brightness LED.
+&lt;a href="https://www.cree.com/led-components/media/documents/XLampXPE2.pdf"&gt;Data sheet&lt;/a&gt;</description>
+<gates>
+<gate name="G$1" symbol="LED-THERMAL" x="0" y="2.54"/>
+</gates>
+<devices>
+<device name="XP-E2" package="XP-E2">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+<connect gate="G$1" pin="X" pad="X"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
 <deviceset name="TEENSY_4.0_SIMPLE">
 <description>Simple version of the Teensy 4.0 board that only uses the 2 main rows of pins, with no perpendicular row with VBat.</description>
 <gates>
@@ -23544,110 +23839,61 @@ DMG3406L (SOT-23, 2.8 A 30V)&lt;br&gt;</description>
 </device>
 </devices>
 </deviceset>
-<deviceset name="TEENSY_4.0_EXT">
-<description>Extended version of the Teensy 4.0 board that only uses the 2 main rows of pins, plus the perpendicular row with VBat.</description>
+<deviceset name="LTC6804-1" uservalue="yes">
 <gates>
-<gate name="G$1" symbol="TEENSY_4.0_EXT" x="-10.16" y="-20.32"/>
+<gate name="G$1" symbol="LTC6804-1" x="-27.94" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="TEENSY_4.0_EXT">
+<device name="" package="LTC6804">
 <connects>
-<connect gate="G$1" pin="(CANRX)A9" pad="(CANRX)A9"/>
-<connect gate="G$1" pin="(CANTX)A8" pad="(CANTX)A8"/>
-<connect gate="G$1" pin="(RX3)A1" pad="(RX3)A1"/>
-<connect gate="G$1" pin="(TX3)A0" pad="(TX3)A0"/>
-<connect gate="G$1" pin="3.3V" pad="3.3V"/>
-<connect gate="G$1" pin="3.3V2" pad="3.3V2"/>
-<connect gate="G$1" pin="A2" pad="A2"/>
-<connect gate="G$1" pin="A3" pad="A3"/>
-<connect gate="G$1" pin="A4" pad="A4"/>
-<connect gate="G$1" pin="A5" pad="A5"/>
-<connect gate="G$1" pin="A6" pad="A6"/>
-<connect gate="G$1" pin="A7" pad="A7"/>
-<connect gate="G$1" pin="D0(RX1)" pad="D0(RX1)"/>
-<connect gate="G$1" pin="D1(TX1)" pad="D1(TX1)"/>
-<connect gate="G$1" pin="D10" pad="D10"/>
-<connect gate="G$1" pin="D11" pad="D11"/>
-<connect gate="G$1" pin="D12" pad="D12"/>
-<connect gate="G$1" pin="D13" pad="D13"/>
-<connect gate="G$1" pin="D2" pad="D2"/>
-<connect gate="G$1" pin="D3" pad="D3"/>
-<connect gate="G$1" pin="D4" pad="D4"/>
-<connect gate="G$1" pin="D5" pad="D5"/>
-<connect gate="G$1" pin="D6" pad="D6"/>
-<connect gate="G$1" pin="D7(RX2)" pad="D7(RX2)"/>
-<connect gate="G$1" pin="D8(TX2\)" pad="D8(TX2)"/>
-<connect gate="G$1" pin="D9" pad="D9"/>
-<connect gate="G$1" pin="GND" pad="GND"/>
-<connect gate="G$1" pin="GND2" pad="GND2"/>
-<connect gate="G$1" pin="GND3" pad="GND3"/>
-<connect gate="G$1" pin="ON/OFF" pad="ON/OFF"/>
-<connect gate="G$1" pin="PGRM" pad="PGRM"/>
-<connect gate="G$1" pin="VBAT" pad="VBAT"/>
-<connect gate="G$1" pin="VIN" pad="VIN"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="TEENSY_3.5_SIMPLE">
-<description>Simple version of the Teensy 3.5 board that only uses the 2 main rows of pins, with no perpendicular row with VBat or inner pins.</description>
-<gates>
-<gate name="G$1" symbol="TEENSY_3.5_SIMPLE" x="0" y="-5.08"/>
-</gates>
-<devices>
-<device name="" package="TEENSY_3.5_SIMPLE">
-<connects>
-<connect gate="G$1" pin="3.3V" pad="3.3V"/>
-<connect gate="G$1" pin="3.3V2" pad="3.3V2"/>
-<connect gate="G$1" pin="A0" pad="A0"/>
-<connect gate="G$1" pin="A1" pad="A1"/>
-<connect gate="G$1" pin="A12" pad="A12"/>
-<connect gate="G$1" pin="A13" pad="A13"/>
-<connect gate="G$1" pin="A14" pad="A14"/>
-<connect gate="G$1" pin="A15" pad="A15"/>
-<connect gate="G$1" pin="A16" pad="A16"/>
-<connect gate="G$1" pin="A17" pad="A17"/>
-<connect gate="G$1" pin="A18" pad="A18"/>
-<connect gate="G$1" pin="A19" pad="A19"/>
-<connect gate="G$1" pin="A2" pad="A2"/>
-<connect gate="G$1" pin="A20" pad="A20"/>
-<connect gate="G$1" pin="A21" pad="A21"/>
-<connect gate="G$1" pin="A22" pad="A22"/>
-<connect gate="G$1" pin="A3" pad="A3"/>
-<connect gate="G$1" pin="A4" pad="A4"/>
-<connect gate="G$1" pin="A5" pad="A5"/>
-<connect gate="G$1" pin="A6" pad="A6"/>
-<connect gate="G$1" pin="A7" pad="A7"/>
-<connect gate="G$1" pin="A8" pad="A8"/>
-<connect gate="G$1" pin="A9" pad="A9"/>
-<connect gate="G$1" pin="AGND" pad="AGND"/>
-<connect gate="G$1" pin="D0(RX1)" pad="D0(RX1)"/>
-<connect gate="G$1" pin="D1(TX1)" pad="D1(TX1)"/>
-<connect gate="G$1" pin="D10(TX2)" pad="D10(TX2)"/>
-<connect gate="G$1" pin="D11" pad="D11"/>
-<connect gate="G$1" pin="D12" pad="D12"/>
-<connect gate="G$1" pin="D13" pad="D13"/>
-<connect gate="G$1" pin="D2" pad="D2"/>
-<connect gate="G$1" pin="D24" pad="D24"/>
-<connect gate="G$1" pin="D25" pad="D25"/>
-<connect gate="G$1" pin="D26" pad="D26"/>
-<connect gate="G$1" pin="D27" pad="D27"/>
-<connect gate="G$1" pin="D28" pad="D28"/>
-<connect gate="G$1" pin="D29" pad="D29"/>
-<connect gate="G$1" pin="D3(CANTX)" pad="D3(CANTX)"/>
-<connect gate="G$1" pin="D30" pad="D30"/>
-<connect gate="G$1" pin="D4(CANRX)" pad="D4(CANRX)"/>
-<connect gate="G$1" pin="D5" pad="D5"/>
-<connect gate="G$1" pin="D6" pad="D6"/>
-<connect gate="G$1" pin="D7(RX3)" pad="D7(RX3)"/>
-<connect gate="G$1" pin="D8(TX3)" pad="D8(TX3)"/>
-<connect gate="G$1" pin="D9(RX2)" pad="D9(RX2)"/>
-<connect gate="G$1" pin="GND" pad="GND"/>
-<connect gate="G$1" pin="GND2" pad="GND2"/>
-<connect gate="G$1" pin="VIN" pad="VIN"/>
+<connect gate="G$1" pin="C0" pad="26"/>
+<connect gate="G$1" pin="C1" pad="24"/>
+<connect gate="G$1" pin="C10" pad="6"/>
+<connect gate="G$1" pin="C11" pad="4"/>
+<connect gate="G$1" pin="C12" pad="2"/>
+<connect gate="G$1" pin="C2" pad="22"/>
+<connect gate="G$1" pin="C3" pad="20"/>
+<connect gate="G$1" pin="C4" pad="18"/>
+<connect gate="G$1" pin="C5" pad="16"/>
+<connect gate="G$1" pin="C6" pad="14"/>
+<connect gate="G$1" pin="C7" pad="12"/>
+<connect gate="G$1" pin="C8" pad="10"/>
+<connect gate="G$1" pin="C9" pad="8"/>
+<connect gate="G$1" pin="CSB(IMA)" pad="41"/>
+<connect gate="G$1" pin="DRIVE" pad="38"/>
+<connect gate="G$1" pin="GPI01" pad="27"/>
+<connect gate="G$1" pin="GPI02" pad="28"/>
+<connect gate="G$1" pin="GPI03" pad="29"/>
+<connect gate="G$1" pin="GPI04" pad="32"/>
+<connect gate="G$1" pin="GPI05" pad="33"/>
+<connect gate="G$1" pin="IBIAS" pad="45"/>
+<connect gate="G$1" pin="ICMP" pad="46"/>
+<connect gate="G$1" pin="IMB" pad="47"/>
+<connect gate="G$1" pin="IPB" pad="48"/>
+<connect gate="G$1" pin="ISOMD" pad="40"/>
+<connect gate="G$1" pin="S1" pad="25"/>
+<connect gate="G$1" pin="S10" pad="7"/>
+<connect gate="G$1" pin="S11" pad="5"/>
+<connect gate="G$1" pin="S12" pad="3"/>
+<connect gate="G$1" pin="S2" pad="23"/>
+<connect gate="G$1" pin="S3" pad="21"/>
+<connect gate="G$1" pin="S4" pad="19"/>
+<connect gate="G$1" pin="S5" pad="17"/>
+<connect gate="G$1" pin="S6" pad="15"/>
+<connect gate="G$1" pin="S7" pad="13"/>
+<connect gate="G$1" pin="S8" pad="11"/>
+<connect gate="G$1" pin="S9" pad="9"/>
+<connect gate="G$1" pin="SCK(IPA)" pad="42"/>
+<connect gate="G$1" pin="SDI(NC)" pad="43"/>
+<connect gate="G$1" pin="SDO(NC)" pad="44"/>
+<connect gate="G$1" pin="SWTEN" pad="36"/>
+<connect gate="G$1" pin="V+" pad="1"/>
+<connect gate="G$1" pin="V-" pad="31"/>
+<connect gate="G$1" pin="V-**" pad="30"/>
+<connect gate="G$1" pin="VREF1" pad="35"/>
+<connect gate="G$1" pin="VREF2" pad="34"/>
+<connect gate="G$1" pin="VREG" pad="37"/>
+<connect gate="G$1" pin="WDT" pad="39"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -23761,337 +24007,22 @@ DMG3406L (SOT-23, 2.8 A 30V)&lt;br&gt;</description>
 </device>
 </devices>
 </deviceset>
-<deviceset name="TEENSY_3.6_EXT_RTC">
-<description>Extended version of the Teensy 3.6 board that only uses the 2 main rows of pins, plus the perpendicular row with VBat.</description>
+<deviceset name="NA555">
+<description>Texas Instruments NA555 timer. &lt;a href="http://www.ti.com/lit/ds/symlink/se555.pdf"&gt;Data sheet&lt;/a&gt;</description>
 <gates>
-<gate name="G$1" symbol="TEENSY_3.6_EXT_RTC" x="0" y="0"/>
+<gate name="G$1" symbol="555_TIMER" x="-12.7" y="-10.16"/>
 </gates>
 <devices>
-<device name="" package="TEENSY_3.6_EXT_RTC">
+<device name="SO-8" package="SOIC-08">
 <connects>
-<connect gate="G$1" pin="3.3V" pad="3.3V"/>
-<connect gate="G$1" pin="3.3V2" pad="3.3V2"/>
-<connect gate="G$1" pin="3.3V3" pad="3.3V3"/>
-<connect gate="G$1" pin="A0" pad="A0"/>
-<connect gate="G$1" pin="A1" pad="A1"/>
-<connect gate="G$1" pin="A12" pad="A12"/>
-<connect gate="G$1" pin="A13" pad="A13"/>
-<connect gate="G$1" pin="A14" pad="A14"/>
-<connect gate="G$1" pin="A15" pad="A15"/>
-<connect gate="G$1" pin="A16" pad="A16"/>
-<connect gate="G$1" pin="A17" pad="A17"/>
-<connect gate="G$1" pin="A18" pad="A18"/>
-<connect gate="G$1" pin="A19" pad="A19"/>
-<connect gate="G$1" pin="A2" pad="A2"/>
-<connect gate="G$1" pin="A20" pad="A20"/>
-<connect gate="G$1" pin="A21" pad="A21"/>
-<connect gate="G$1" pin="A22" pad="A22"/>
-<connect gate="G$1" pin="A3" pad="A3"/>
-<connect gate="G$1" pin="A4" pad="A4"/>
-<connect gate="G$1" pin="A5" pad="A5"/>
-<connect gate="G$1" pin="A6" pad="A6"/>
-<connect gate="G$1" pin="A7" pad="A7"/>
-<connect gate="G$1" pin="A8" pad="A8"/>
-<connect gate="G$1" pin="A9" pad="A9"/>
-<connect gate="G$1" pin="AGND" pad="AGND"/>
-<connect gate="G$1" pin="D0(RX1)" pad="D0(RX1)"/>
-<connect gate="G$1" pin="D1(TX1)" pad="D1(TX1)"/>
-<connect gate="G$1" pin="D10(TX2)" pad="D10(TX2)"/>
-<connect gate="G$1" pin="D11" pad="D11"/>
-<connect gate="G$1" pin="D12" pad="D12"/>
-<connect gate="G$1" pin="D13" pad="D13"/>
-<connect gate="G$1" pin="D2" pad="D2"/>
-<connect gate="G$1" pin="D24" pad="D24"/>
-<connect gate="G$1" pin="D25" pad="D25"/>
-<connect gate="G$1" pin="D26" pad="D26"/>
-<connect gate="G$1" pin="D27" pad="D27"/>
-<connect gate="G$1" pin="D28" pad="D28"/>
-<connect gate="G$1" pin="D29" pad="D29"/>
-<connect gate="G$1" pin="D3(CANTX)" pad="D3(CANTX)"/>
-<connect gate="G$1" pin="D30" pad="D30"/>
-<connect gate="G$1" pin="D4(CANRX)" pad="D4(CANRX)"/>
-<connect gate="G$1" pin="D5" pad="D5"/>
-<connect gate="G$1" pin="D6" pad="D6"/>
-<connect gate="G$1" pin="D7(RX3)" pad="D7(RX3)"/>
-<connect gate="G$1" pin="D8(TX3)" pad="D8(TX3)"/>
-<connect gate="G$1" pin="D9(RX2)" pad="D9(RX2)"/>
-<connect gate="G$1" pin="GND" pad="GND"/>
-<connect gate="G$1" pin="GND2" pad="GND2"/>
-<connect gate="G$1" pin="GND3" pad="GND3"/>
-<connect gate="G$1" pin="PRGM" pad="PRGM"/>
-<connect gate="G$1" pin="RST" pad="RST"/>
-<connect gate="G$1" pin="VBAT" pad="VBAT"/>
-<connect gate="G$1" pin="VIN" pad="VIN"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="JUMPER_SWITCH_2" prefix="J">
-<description>Jumper Switch: Switch between 2 circuits by cutting default trace and soldering pads together.</description>
-<gates>
-<gate name="G$1" symbol="JUMPER_SWITCH_2" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="JUMPER_SWITCH_2">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-<connect gate="G$1" pin="P$2" pad="P$2"/>
-<connect gate="G$1" pin="P$3" pad="P$3"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="JUMPER_SWITCH_1" prefix="J">
-<description>Jumper Switch: Switch a circuit by cutting trace or soldering pads back together.</description>
-<gates>
-<gate name="G$1" symbol="JUMPER_SWITCH_1" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="JUMPER_SWITCH_1">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-<connect gate="G$1" pin="P$2" pad="P$2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="DMG2305UX">
-<description>P-CHANNEL ENHANCEMENT MODE MOSFET</description>
-<gates>
-<gate name="G$1" symbol="P-CHANNEL_MOSFET" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="SOT23">
-<connects>
-<connect gate="G$1" pin="D" pad="3"/>
-<connect gate="G$1" pin="G" pad="1"/>
-<connect gate="G$1" pin="S" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="DMMT5401">
-<gates>
-<gate name="G$1" symbol="PNP_BJT" x="-10.16" y="0"/>
-<gate name="G$2" symbol="PNP_BJT" x="10.16" y="0"/>
-</gates>
-<devices>
-<device name="" package="SOT26">
-<connects>
-<connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="6"/>
-<connect gate="G$2" pin="B" pad="3"/>
-<connect gate="G$2" pin="C" pad="4"/>
-<connect gate="G$2" pin="E" pad="5"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="CRYSTAL_GROUNDED">
-<gates>
-<gate name="G$1" symbol="Q-SHIELD2" x="0" y="0"/>
-</gates>
-<devices>
-<device name="_3.2X2.5MM" package="CRYSTAL_3.2X2.5MM">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-<connect gate="G$1" pin="3" pad="P$3"/>
-<connect gate="G$1" pin="4" pad="P$4"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="OKI-78SR-3.3">
-<description>Murata OKI-78SR 5V 1.5A Non-Isolated Switching Regulator DC/DC - &lt;a href="https://power.murata.com/data/power/oki-78sr.pdf"&gt;Datasheet&lt;/a&gt;</description>
-<gates>
-<gate name="G$1" symbol="VOLTAGE_REGULATOR" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="OKI-78SR">
-<connects>
-<connect gate="G$1" pin="GND" pad="2"/>
-<connect gate="G$1" pin="IN" pad="1"/>
-<connect gate="G$1" pin="OUT" pad="3"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="MAX31855KASA+" prefix="U">
-<gates>
-<gate name="A" symbol="MAX31855KASA+" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="21-0041B_8">
-<connects>
-<connect gate="A" pin="!CS" pad="6"/>
-<connect gate="A" pin="DNC" pad="8"/>
-<connect gate="A" pin="GND" pad="1"/>
-<connect gate="A" pin="SCK" pad="5"/>
-<connect gate="A" pin="SO" pad="7"/>
-<connect gate="A" pin="T+" pad="3"/>
-<connect gate="A" pin="T-" pad="2"/>
-<connect gate="A" pin="VCC" pad="4"/>
-</connects>
-<technologies>
-<technology name="">
-<attribute name="MANUFACTURER_PART_NUMBER" value="MAX31855KASA+" constant="no"/>
-<attribute name="VENDOR" value="Maxim Integrated Products" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="21-0041B_8-M" package="21-0041B_8-M">
-<connects>
-<connect gate="A" pin="!CS" pad="6"/>
-<connect gate="A" pin="DNC" pad="8"/>
-<connect gate="A" pin="GND" pad="1"/>
-<connect gate="A" pin="SCK" pad="5"/>
-<connect gate="A" pin="SO" pad="7"/>
-<connect gate="A" pin="T+" pad="3"/>
-<connect gate="A" pin="T-" pad="2"/>
-<connect gate="A" pin="VCC" pad="4"/>
-</connects>
-<technologies>
-<technology name="">
-<attribute name="MANUFACTURER_PART_NUMBER" value="MAX31855KASA+" constant="no"/>
-<attribute name="VENDOR" value="Maxim Integrated Products" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="21-0041B_8-L" package="21-0041B_8-L">
-<connects>
-<connect gate="A" pin="!CS" pad="6"/>
-<connect gate="A" pin="DNC" pad="8"/>
-<connect gate="A" pin="GND" pad="1"/>
-<connect gate="A" pin="SCK" pad="5"/>
-<connect gate="A" pin="SO" pad="7"/>
-<connect gate="A" pin="T+" pad="3"/>
-<connect gate="A" pin="T-" pad="2"/>
-<connect gate="A" pin="VCC" pad="4"/>
-</connects>
-<technologies>
-<technology name="">
-<attribute name="MANUFACTURER_PART_NUMBER" value="MAX31855KASA+" constant="no"/>
-<attribute name="VENDOR" value="Maxim Integrated Products" constant="no"/>
-</technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="ACHS-7121">
-<gates>
-<gate name="G$1" symbol="ACHS-7121" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="SOP8">
-<connects>
-<connect gate="G$1" pin="FILTER" pad="6"/>
-<connect gate="G$1" pin="GND" pad="5"/>
-<connect gate="G$1" pin="IP+" pad="1 2"/>
-<connect gate="G$1" pin="IP-" pad="3 4"/>
-<connect gate="G$1" pin="VDD" pad="8"/>
-<connect gate="G$1" pin="VOUT" pad="7"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="PCC-SMP-K-100-R-ROHS" prefix="J">
-<description>&lt;b&gt;NEWPORT ELECTRONICS - PCC-SMP-K-100-R-ROHS - CIRCUIT BOARD THERMOCOUPLE, K TYPE&lt;/b&gt;&lt;p&gt;
-Source: &lt;a href="http://www.farnell.com/datasheets/1789660.pdf"&gt; Datasheet &lt;/a&gt;</description>
-<gates>
-<gate name="G$1" symbol="PCC-SMP-K-100-R-ROHS" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="PCC-SMP">
-<connects>
-<connect gate="G$1" pin="+" pad="1"/>
-<connect gate="G$1" pin="-" pad="2"/>
-</connects>
-<technologies>
-<technology name="">
-<attribute name="DESCRIPTION" value="NEWPORT ELECTRONICS - PCC-SMP-K-100-R-ROHS - CIRCUIT BOARD THERMOCOUPLE, K TYPE" constant="no"/>
-<attribute name="HEIGHT" value="mm" constant="no"/>
-<attribute name="MANUFACTURER_NAME" value="NEWPORT ELECTRONICS" constant="no"/>
-<attribute name="MANUFACTURER_PART_NUMBER" value="PCC-SMP-K-100-R-ROHS" constant="no"/>
-<attribute name="MOUSER_PART_NUMBER" value="" constant="no"/>
-<attribute name="MOUSER_PRICE-STOCK" value="" constant="no"/>
-<attribute name="RS_PART_NUMBER" value="" constant="no"/>
-<attribute name="RS_PRICE-STOCK" value="" constant="no"/>
-</technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="LTC6081">
-<gates>
-<gate name="G$1" symbol="OPAMP_2_CHANNEL" x="-43.18" y="5.08"/>
-</gates>
-<devices>
-<device name="" package="MSOP-8_MS">
-<connects>
-<connect gate="G$1" pin="VDD" pad="8"/>
-<connect gate="G$1" pin="VINA+" pad="3"/>
-<connect gate="G$1" pin="VINA-" pad="2"/>
-<connect gate="G$1" pin="VINB+" pad="5"/>
-<connect gate="G$1" pin="VINB-" pad="6"/>
-<connect gate="G$1" pin="VOUTA" pad="1"/>
-<connect gate="G$1" pin="VOUTB" pad="7"/>
-<connect gate="G$1" pin="VSS" pad="4"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-M" package="MSOP-8_MS-M">
-<connects>
-<connect gate="G$1" pin="VDD" pad="8"/>
-<connect gate="G$1" pin="VINA+" pad="3"/>
-<connect gate="G$1" pin="VINA-" pad="2"/>
-<connect gate="G$1" pin="VINB+" pad="5"/>
-<connect gate="G$1" pin="VINB-" pad="6"/>
-<connect gate="G$1" pin="VOUTA" pad="1"/>
-<connect gate="G$1" pin="VOUTB" pad="7"/>
-<connect gate="G$1" pin="VSS" pad="4"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-L" package="MSOP-8_MS-L">
-<connects>
-<connect gate="G$1" pin="VDD" pad="8"/>
-<connect gate="G$1" pin="VINA+" pad="3"/>
-<connect gate="G$1" pin="VINA-" pad="2"/>
-<connect gate="G$1" pin="VINB+" pad="5"/>
-<connect gate="G$1" pin="VINB-" pad="6"/>
-<connect gate="G$1" pin="VOUTA" pad="1"/>
-<connect gate="G$1" pin="VOUTB" pad="7"/>
-<connect gate="G$1" pin="VSS" pad="4"/>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+<connect gate="G$1" pin="7" pad="7"/>
+<connect gate="G$1" pin="8" pad="8"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -24178,6 +24109,54 @@ Source: &lt;a href="http://www.farnell.com/datasheets/1789660.pdf"&gt; Datasheet
 </device>
 </devices>
 </deviceset>
+<deviceset name="TEENSY_4.0_EXT">
+<description>Extended version of the Teensy 4.0 board that only uses the 2 main rows of pins, plus the perpendicular row with VBat.</description>
+<gates>
+<gate name="G$1" symbol="TEENSY_4.0_EXT" x="-10.16" y="-20.32"/>
+</gates>
+<devices>
+<device name="" package="TEENSY_4.0_EXT">
+<connects>
+<connect gate="G$1" pin="(CANRX)A9" pad="(CANRX)A9"/>
+<connect gate="G$1" pin="(CANTX)A8" pad="(CANTX)A8"/>
+<connect gate="G$1" pin="(RX3)A1" pad="(RX3)A1"/>
+<connect gate="G$1" pin="(TX3)A0" pad="(TX3)A0"/>
+<connect gate="G$1" pin="3.3V" pad="3.3V"/>
+<connect gate="G$1" pin="3.3V2" pad="3.3V2"/>
+<connect gate="G$1" pin="A2" pad="A2"/>
+<connect gate="G$1" pin="A3" pad="A3"/>
+<connect gate="G$1" pin="A4" pad="A4"/>
+<connect gate="G$1" pin="A5" pad="A5"/>
+<connect gate="G$1" pin="A6" pad="A6"/>
+<connect gate="G$1" pin="A7" pad="A7"/>
+<connect gate="G$1" pin="D0(RX1)" pad="D0(RX1)"/>
+<connect gate="G$1" pin="D1(TX1)" pad="D1(TX1)"/>
+<connect gate="G$1" pin="D10" pad="D10"/>
+<connect gate="G$1" pin="D11" pad="D11"/>
+<connect gate="G$1" pin="D12" pad="D12"/>
+<connect gate="G$1" pin="D13" pad="D13"/>
+<connect gate="G$1" pin="D2" pad="D2"/>
+<connect gate="G$1" pin="D3" pad="D3"/>
+<connect gate="G$1" pin="D4" pad="D4"/>
+<connect gate="G$1" pin="D5" pad="D5"/>
+<connect gate="G$1" pin="D6" pad="D6"/>
+<connect gate="G$1" pin="D7(RX2)" pad="D7(RX2)"/>
+<connect gate="G$1" pin="D8(TX2\)" pad="D8(TX2)"/>
+<connect gate="G$1" pin="D9" pad="D9"/>
+<connect gate="G$1" pin="GND" pad="GND"/>
+<connect gate="G$1" pin="GND2" pad="GND2"/>
+<connect gate="G$1" pin="GND3" pad="GND3"/>
+<connect gate="G$1" pin="ON/OFF" pad="ON/OFF"/>
+<connect gate="G$1" pin="PGRM" pad="PGRM"/>
+<connect gate="G$1" pin="VBAT" pad="VBAT"/>
+<connect gate="G$1" pin="VIN" pad="VIN"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
 <deviceset name="CONNECTOR-22">
 <description>22-pin Autosport connector</description>
 <gates>
@@ -24217,6 +24196,297 @@ Source: &lt;a href="http://www.farnell.com/datasheets/1789660.pdf"&gt; Datasheet
 </device>
 </devices>
 </deviceset>
+<deviceset name="TEENSY_3.6_EXT_RTC">
+<description>Extended version of the Teensy 3.6 board that only uses the 2 main rows of pins, plus the perpendicular row with VBat.</description>
+<gates>
+<gate name="G$1" symbol="TEENSY_3.6_EXT_RTC" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="TEENSY_3.6_EXT_RTC">
+<connects>
+<connect gate="G$1" pin="3.3V" pad="3.3V"/>
+<connect gate="G$1" pin="3.3V2" pad="3.3V2"/>
+<connect gate="G$1" pin="3.3V3" pad="3.3V3"/>
+<connect gate="G$1" pin="A0" pad="A0"/>
+<connect gate="G$1" pin="A1" pad="A1"/>
+<connect gate="G$1" pin="A12" pad="A12"/>
+<connect gate="G$1" pin="A13" pad="A13"/>
+<connect gate="G$1" pin="A14" pad="A14"/>
+<connect gate="G$1" pin="A15" pad="A15"/>
+<connect gate="G$1" pin="A16" pad="A16"/>
+<connect gate="G$1" pin="A17" pad="A17"/>
+<connect gate="G$1" pin="A18" pad="A18"/>
+<connect gate="G$1" pin="A19" pad="A19"/>
+<connect gate="G$1" pin="A2" pad="A2"/>
+<connect gate="G$1" pin="A20" pad="A20"/>
+<connect gate="G$1" pin="A21" pad="A21"/>
+<connect gate="G$1" pin="A22" pad="A22"/>
+<connect gate="G$1" pin="A3" pad="A3"/>
+<connect gate="G$1" pin="A4" pad="A4"/>
+<connect gate="G$1" pin="A5" pad="A5"/>
+<connect gate="G$1" pin="A6" pad="A6"/>
+<connect gate="G$1" pin="A7" pad="A7"/>
+<connect gate="G$1" pin="A8" pad="A8"/>
+<connect gate="G$1" pin="A9" pad="A9"/>
+<connect gate="G$1" pin="AGND" pad="AGND"/>
+<connect gate="G$1" pin="D0(RX1)" pad="D0(RX1)"/>
+<connect gate="G$1" pin="D1(TX1)" pad="D1(TX1)"/>
+<connect gate="G$1" pin="D10(TX2)" pad="D10(TX2)"/>
+<connect gate="G$1" pin="D11" pad="D11"/>
+<connect gate="G$1" pin="D12" pad="D12"/>
+<connect gate="G$1" pin="D13" pad="D13"/>
+<connect gate="G$1" pin="D2" pad="D2"/>
+<connect gate="G$1" pin="D24" pad="D24"/>
+<connect gate="G$1" pin="D25" pad="D25"/>
+<connect gate="G$1" pin="D26" pad="D26"/>
+<connect gate="G$1" pin="D27" pad="D27"/>
+<connect gate="G$1" pin="D28" pad="D28"/>
+<connect gate="G$1" pin="D29" pad="D29"/>
+<connect gate="G$1" pin="D3(CANTX)" pad="D3(CANTX)"/>
+<connect gate="G$1" pin="D30" pad="D30"/>
+<connect gate="G$1" pin="D4(CANRX)" pad="D4(CANRX)"/>
+<connect gate="G$1" pin="D5" pad="D5"/>
+<connect gate="G$1" pin="D6" pad="D6"/>
+<connect gate="G$1" pin="D7(RX3)" pad="D7(RX3)"/>
+<connect gate="G$1" pin="D8(TX3)" pad="D8(TX3)"/>
+<connect gate="G$1" pin="D9(RX2)" pad="D9(RX2)"/>
+<connect gate="G$1" pin="GND" pad="GND"/>
+<connect gate="G$1" pin="GND2" pad="GND2"/>
+<connect gate="G$1" pin="GND3" pad="GND3"/>
+<connect gate="G$1" pin="PRGM" pad="PRGM"/>
+<connect gate="G$1" pin="RST" pad="RST"/>
+<connect gate="G$1" pin="VBAT" pad="VBAT"/>
+<connect gate="G$1" pin="VIN" pad="VIN"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="TEENSY_3.5_SIMPLE">
+<description>Simple version of the Teensy 3.5 board that only uses the 2 main rows of pins, with no perpendicular row with VBat or inner pins.</description>
+<gates>
+<gate name="G$1" symbol="TEENSY_3.5_SIMPLE" x="0" y="-5.08"/>
+</gates>
+<devices>
+<device name="" package="TEENSY_3.5_SIMPLE">
+<connects>
+<connect gate="G$1" pin="3.3V" pad="3.3V"/>
+<connect gate="G$1" pin="3.3V2" pad="3.3V2"/>
+<connect gate="G$1" pin="A0" pad="A0"/>
+<connect gate="G$1" pin="A1" pad="A1"/>
+<connect gate="G$1" pin="A12" pad="A12"/>
+<connect gate="G$1" pin="A13" pad="A13"/>
+<connect gate="G$1" pin="A14" pad="A14"/>
+<connect gate="G$1" pin="A15" pad="A15"/>
+<connect gate="G$1" pin="A16" pad="A16"/>
+<connect gate="G$1" pin="A17" pad="A17"/>
+<connect gate="G$1" pin="A18" pad="A18"/>
+<connect gate="G$1" pin="A19" pad="A19"/>
+<connect gate="G$1" pin="A2" pad="A2"/>
+<connect gate="G$1" pin="A20" pad="A20"/>
+<connect gate="G$1" pin="A21" pad="A21"/>
+<connect gate="G$1" pin="A22" pad="A22"/>
+<connect gate="G$1" pin="A3" pad="A3"/>
+<connect gate="G$1" pin="A4" pad="A4"/>
+<connect gate="G$1" pin="A5" pad="A5"/>
+<connect gate="G$1" pin="A6" pad="A6"/>
+<connect gate="G$1" pin="A7" pad="A7"/>
+<connect gate="G$1" pin="A8" pad="A8"/>
+<connect gate="G$1" pin="A9" pad="A9"/>
+<connect gate="G$1" pin="AGND" pad="AGND"/>
+<connect gate="G$1" pin="D0(RX1)" pad="D0(RX1)"/>
+<connect gate="G$1" pin="D1(TX1)" pad="D1(TX1)"/>
+<connect gate="G$1" pin="D10(TX2)" pad="D10(TX2)"/>
+<connect gate="G$1" pin="D11" pad="D11"/>
+<connect gate="G$1" pin="D12" pad="D12"/>
+<connect gate="G$1" pin="D13" pad="D13"/>
+<connect gate="G$1" pin="D2" pad="D2"/>
+<connect gate="G$1" pin="D24" pad="D24"/>
+<connect gate="G$1" pin="D25" pad="D25"/>
+<connect gate="G$1" pin="D26" pad="D26"/>
+<connect gate="G$1" pin="D27" pad="D27"/>
+<connect gate="G$1" pin="D28" pad="D28"/>
+<connect gate="G$1" pin="D29" pad="D29"/>
+<connect gate="G$1" pin="D3(CANTX)" pad="D3(CANTX)"/>
+<connect gate="G$1" pin="D30" pad="D30"/>
+<connect gate="G$1" pin="D4(CANRX)" pad="D4(CANRX)"/>
+<connect gate="G$1" pin="D5" pad="D5"/>
+<connect gate="G$1" pin="D6" pad="D6"/>
+<connect gate="G$1" pin="D7(RX3)" pad="D7(RX3)"/>
+<connect gate="G$1" pin="D8(TX3)" pad="D8(TX3)"/>
+<connect gate="G$1" pin="D9(RX2)" pad="D9(RX2)"/>
+<connect gate="G$1" pin="GND" pad="GND"/>
+<connect gate="G$1" pin="GND2" pad="GND2"/>
+<connect gate="G$1" pin="VIN" pad="VIN"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="TEENSY_3.2_EXT_12ANALOG">
+<description>Simple version of the Teensy 3.2 board that only uses the 2 main rows of pins, with 12 Analog pins and no perpendicular row with VBat or inner pins.</description>
+<gates>
+<gate name="G$1" symbol="TEENSY_3.2_EXT_12ANALOG" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="TEENSY_3.2_EXT_12ANALOG">
+<connects>
+<connect gate="G$1" pin="3.3V" pad="3.3V"/>
+<connect gate="G$1" pin="A0" pad="A0"/>
+<connect gate="G$1" pin="A1" pad="A1"/>
+<connect gate="G$1" pin="A10" pad="A10"/>
+<connect gate="G$1" pin="A11" pad="A11"/>
+<connect gate="G$1" pin="A2" pad="A2"/>
+<connect gate="G$1" pin="A3" pad="A3"/>
+<connect gate="G$1" pin="A4" pad="A4"/>
+<connect gate="G$1" pin="A5" pad="A5"/>
+<connect gate="G$1" pin="A6" pad="A6"/>
+<connect gate="G$1" pin="A7" pad="A7"/>
+<connect gate="G$1" pin="A8" pad="A8"/>
+<connect gate="G$1" pin="A9" pad="A9"/>
+<connect gate="G$1" pin="AGND" pad="AGND"/>
+<connect gate="G$1" pin="D0(RX1)" pad="D0(RX1)"/>
+<connect gate="G$1" pin="D1(TX1)" pad="D1(TX1)"/>
+<connect gate="G$1" pin="D10(TX2)" pad="D10(TX2)"/>
+<connect gate="G$1" pin="D11" pad="D11"/>
+<connect gate="G$1" pin="D12" pad="D12"/>
+<connect gate="G$1" pin="D13" pad="D13"/>
+<connect gate="G$1" pin="D2" pad="D2"/>
+<connect gate="G$1" pin="D3(CANTX)" pad="D3(CANTX)"/>
+<connect gate="G$1" pin="D4(CANRX)" pad="D4(CANRX)"/>
+<connect gate="G$1" pin="D5" pad="D5"/>
+<connect gate="G$1" pin="D6" pad="D6"/>
+<connect gate="G$1" pin="D7(RX3)" pad="D7(RX3)"/>
+<connect gate="G$1" pin="D8(TX3)" pad="D8(TX3)"/>
+<connect gate="G$1" pin="D9(RX2)" pad="D9(RX2)"/>
+<connect gate="G$1" pin="GND" pad="GND"/>
+<connect gate="G$1" pin="VIN" pad="VIN"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="TEENSY_3.5_EXT_RTC">
+<description>Extended version of the Teensy 3.5 board that only uses the 2 main rows of pins, plus the perpendicular row with VBat.</description>
+<gates>
+<gate name="G$1" symbol="TEENSY_3.5_EXT_RTC" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="TEENSY_3.5_EXT_RTC">
+<connects>
+<connect gate="G$1" pin="3.3V" pad="3.3V"/>
+<connect gate="G$1" pin="3.3V2" pad="3.3V2"/>
+<connect gate="G$1" pin="3.3V3" pad="3.3V3"/>
+<connect gate="G$1" pin="A0" pad="A0"/>
+<connect gate="G$1" pin="A1" pad="A1"/>
+<connect gate="G$1" pin="A12" pad="A12"/>
+<connect gate="G$1" pin="A13" pad="A13"/>
+<connect gate="G$1" pin="A14" pad="A14"/>
+<connect gate="G$1" pin="A15" pad="A15"/>
+<connect gate="G$1" pin="A16" pad="A16"/>
+<connect gate="G$1" pin="A17" pad="A17"/>
+<connect gate="G$1" pin="A18" pad="A18"/>
+<connect gate="G$1" pin="A19" pad="A19"/>
+<connect gate="G$1" pin="A2" pad="A2"/>
+<connect gate="G$1" pin="A20" pad="A20"/>
+<connect gate="G$1" pin="A21" pad="A21"/>
+<connect gate="G$1" pin="A22" pad="A22"/>
+<connect gate="G$1" pin="A3" pad="A3"/>
+<connect gate="G$1" pin="A4" pad="A4"/>
+<connect gate="G$1" pin="A5" pad="A5"/>
+<connect gate="G$1" pin="A6" pad="A6"/>
+<connect gate="G$1" pin="A7" pad="A7"/>
+<connect gate="G$1" pin="A8" pad="A8"/>
+<connect gate="G$1" pin="A9" pad="A9"/>
+<connect gate="G$1" pin="AGND" pad="AGND"/>
+<connect gate="G$1" pin="D0(RX1)" pad="D0(RX1)"/>
+<connect gate="G$1" pin="D1(TX1)" pad="D1(TX1)"/>
+<connect gate="G$1" pin="D10(TX2)" pad="D10(TX2)"/>
+<connect gate="G$1" pin="D11" pad="D11"/>
+<connect gate="G$1" pin="D12" pad="D12"/>
+<connect gate="G$1" pin="D13" pad="D13"/>
+<connect gate="G$1" pin="D2" pad="D2"/>
+<connect gate="G$1" pin="D24" pad="D24"/>
+<connect gate="G$1" pin="D25" pad="D25"/>
+<connect gate="G$1" pin="D26" pad="D26"/>
+<connect gate="G$1" pin="D27" pad="D27"/>
+<connect gate="G$1" pin="D28" pad="D28"/>
+<connect gate="G$1" pin="D29" pad="D29"/>
+<connect gate="G$1" pin="D3(CANTX)" pad="D3(CANTX)"/>
+<connect gate="G$1" pin="D30" pad="D30"/>
+<connect gate="G$1" pin="D4(CANRX)" pad="D4(CANRX)"/>
+<connect gate="G$1" pin="D5" pad="D5"/>
+<connect gate="G$1" pin="D6" pad="D6"/>
+<connect gate="G$1" pin="D7(RX3)" pad="D7(RX3)"/>
+<connect gate="G$1" pin="D8(TX3)" pad="D8(TX3)"/>
+<connect gate="G$1" pin="D9(RX2)" pad="D9(RX2)"/>
+<connect gate="G$1" pin="GND" pad="GND"/>
+<connect gate="G$1" pin="GND2" pad="GND2"/>
+<connect gate="G$1" pin="GND3" pad="GND3"/>
+<connect gate="G$1" pin="PRGM" pad="PRGM"/>
+<connect gate="G$1" pin="RST" pad="RST"/>
+<connect gate="G$1" pin="VBAT" pad="VBAT"/>
+<connect gate="G$1" pin="VIN" pad="VIN"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="PCC-SMP-K-100-R-ROHS" prefix="J">
+<description>&lt;b&gt;NEWPORT ELECTRONICS - PCC-SMP-K-100-R-ROHS - CIRCUIT BOARD THERMOCOUPLE, K TYPE&lt;/b&gt;&lt;p&gt;
+Source: &lt;a href="http://www.farnell.com/datasheets/1789660.pdf"&gt; Datasheet &lt;/a&gt;</description>
+<gates>
+<gate name="G$1" symbol="PCC-SMP-K-100-R-ROHS" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="PCC-SMP">
+<connects>
+<connect gate="G$1" pin="+" pad="1"/>
+<connect gate="G$1" pin="-" pad="2"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="DESCRIPTION" value="NEWPORT ELECTRONICS - PCC-SMP-K-100-R-ROHS - CIRCUIT BOARD THERMOCOUPLE, K TYPE" constant="no"/>
+<attribute name="HEIGHT" value="mm" constant="no"/>
+<attribute name="MANUFACTURER_NAME" value="NEWPORT ELECTRONICS" constant="no"/>
+<attribute name="MANUFACTURER_PART_NUMBER" value="PCC-SMP-K-100-R-ROHS" constant="no"/>
+<attribute name="MOUSER_PART_NUMBER" value="" constant="no"/>
+<attribute name="MOUSER_PRICE-STOCK" value="" constant="no"/>
+<attribute name="RS_PART_NUMBER" value="" constant="no"/>
+<attribute name="RS_PRICE-STOCK" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="ACHS-7121">
+<gates>
+<gate name="G$1" symbol="ACHS-7121" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="SOP8">
+<connects>
+<connect gate="G$1" pin="FILTER" pad="6"/>
+<connect gate="G$1" pin="GND" pad="5"/>
+<connect gate="G$1" pin="IP+" pad="1 2"/>
+<connect gate="G$1" pin="IP-" pad="3 4"/>
+<connect gate="G$1" pin="VDD" pad="8"/>
+<connect gate="G$1" pin="VOUT" pad="7"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
 <deviceset name="10118192-0001LF" prefix="J">
 <description>Single Port 5 Contact Horizontal Right Angle Shielded Micro B USB 2.0 Connector</description>
 <gates>
@@ -24241,6 +24511,58 @@ Source: &lt;a href="http://www.farnell.com/datasheets/1789660.pdf"&gt; Datasheet
 <attribute name="PACKAGE" value="None"/>
 <attribute name="PRICE" value="None"/>
 </technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="LTC6081">
+<gates>
+<gate name="G$1" symbol="OPAMP_2_CHANNEL" x="-43.18" y="5.08"/>
+</gates>
+<devices>
+<device name="" package="MSOP-8_MS">
+<connects>
+<connect gate="G$1" pin="VDD" pad="8"/>
+<connect gate="G$1" pin="VINA+" pad="3"/>
+<connect gate="G$1" pin="VINA-" pad="2"/>
+<connect gate="G$1" pin="VINB+" pad="5"/>
+<connect gate="G$1" pin="VINB-" pad="6"/>
+<connect gate="G$1" pin="VOUTA" pad="1"/>
+<connect gate="G$1" pin="VOUTB" pad="7"/>
+<connect gate="G$1" pin="VSS" pad="4"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-M" package="MSOP-8_MS-M">
+<connects>
+<connect gate="G$1" pin="VDD" pad="8"/>
+<connect gate="G$1" pin="VINA+" pad="3"/>
+<connect gate="G$1" pin="VINA-" pad="2"/>
+<connect gate="G$1" pin="VINB+" pad="5"/>
+<connect gate="G$1" pin="VINB-" pad="6"/>
+<connect gate="G$1" pin="VOUTA" pad="1"/>
+<connect gate="G$1" pin="VOUTB" pad="7"/>
+<connect gate="G$1" pin="VSS" pad="4"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-L" package="MSOP-8_MS-L">
+<connects>
+<connect gate="G$1" pin="VDD" pad="8"/>
+<connect gate="G$1" pin="VINA+" pad="3"/>
+<connect gate="G$1" pin="VINA-" pad="2"/>
+<connect gate="G$1" pin="VINB+" pad="5"/>
+<connect gate="G$1" pin="VINB-" pad="6"/>
+<connect gate="G$1" pin="VOUTA" pad="1"/>
+<connect gate="G$1" pin="VOUTB" pad="7"/>
+<connect gate="G$1" pin="VSS" pad="4"/>
+</connects>
+<technologies>
+<technology name=""/>
 </technologies>
 </device>
 </devices>
@@ -24275,18 +24597,47 @@ Source: &lt;a href="http://www.farnell.com/datasheets/1789660.pdf"&gt; Datasheet
 </device>
 </devices>
 </deviceset>
-<deviceset name="XP-E2">
-<description>XP-E2 high-brightness LED.
-&lt;a href="https://www.cree.com/led-components/media/documents/XLampXPE2.pdf"&gt;Data sheet&lt;/a&gt;</description>
+<deviceset name="TEENSY_LC_EXT">
+<description>Extended version of the Teensy LC board that only uses the 2 main rows of pins, plus the perpendicular row with VBat.</description>
 <gates>
-<gate name="G$1" symbol="LED-THERMAL" x="0" y="2.54"/>
+<gate name="G$1" symbol="TEENSY_LC_EXT" x="0" y="0"/>
 </gates>
 <devices>
-<device name="XP-E2" package="XP-E2">
+<device name="" package="TEENSY_LC_EXT">
 <connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="X" pad="X"/>
+<connect gate="G$1" pin="3.3V" pad="3.3V"/>
+<connect gate="G$1" pin="3.3V2" pad="3.3V2"/>
+<connect gate="G$1" pin="A0" pad="A0"/>
+<connect gate="G$1" pin="A1" pad="A1"/>
+<connect gate="G$1" pin="A2" pad="A2"/>
+<connect gate="G$1" pin="A3" pad="A3"/>
+<connect gate="G$1" pin="A4" pad="A4"/>
+<connect gate="G$1" pin="A5" pad="A5"/>
+<connect gate="G$1" pin="A6" pad="A6"/>
+<connect gate="G$1" pin="A7" pad="A7"/>
+<connect gate="G$1" pin="A8" pad="A8"/>
+<connect gate="G$1" pin="A9" pad="A9"/>
+<connect gate="G$1" pin="AGND" pad="AGND"/>
+<connect gate="G$1" pin="D0(RX1)" pad="D0(RX1)"/>
+<connect gate="G$1" pin="D1(TX1)" pad="D1(TX1)"/>
+<connect gate="G$1" pin="D10(TX2)" pad="D10(TX2)"/>
+<connect gate="G$1" pin="D11" pad="D11"/>
+<connect gate="G$1" pin="D12" pad="D12"/>
+<connect gate="G$1" pin="D13" pad="D13"/>
+<connect gate="G$1" pin="D17" pad="D17"/>
+<connect gate="G$1" pin="D2" pad="D2"/>
+<connect gate="G$1" pin="D3" pad="D3"/>
+<connect gate="G$1" pin="D4" pad="D4"/>
+<connect gate="G$1" pin="D5" pad="D5"/>
+<connect gate="G$1" pin="D6" pad="D6"/>
+<connect gate="G$1" pin="D7(RX3)" pad="D7(RX3)"/>
+<connect gate="G$1" pin="D8(TX3)" pad="D8(TX3)"/>
+<connect gate="G$1" pin="D9(RX2)" pad="D9(RX2)"/>
+<connect gate="G$1" pin="DAC" pad="DAC"/>
+<connect gate="G$1" pin="GND" pad="GND"/>
+<connect gate="G$1" pin="GND2" pad="GND2"/>
+<connect gate="G$1" pin="PGRM" pad="PGRM"/>
+<connect gate="G$1" pin="VIN" pad="VIN"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -24294,22 +24645,293 @@ Source: &lt;a href="http://www.farnell.com/datasheets/1789660.pdf"&gt; Datasheet
 </device>
 </devices>
 </deviceset>
-<deviceset name="NA555">
-<description>Texas Instruments NA555 timer. &lt;a href="http://www.ti.com/lit/ds/symlink/se555.pdf"&gt;Data sheet&lt;/a&gt;</description>
+<deviceset name="MAX31855KASA+" prefix="U">
 <gates>
-<gate name="G$1" symbol="555_TIMER" x="-12.7" y="-10.16"/>
+<gate name="A" symbol="MAX31855KASA+" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO-8" package="SOIC-08">
+<device name="" package="21-0041B_8">
+<connects>
+<connect gate="A" pin="!CS" pad="6"/>
+<connect gate="A" pin="DNC" pad="8"/>
+<connect gate="A" pin="GND" pad="1"/>
+<connect gate="A" pin="SCK" pad="5"/>
+<connect gate="A" pin="SO" pad="7"/>
+<connect gate="A" pin="T+" pad="3"/>
+<connect gate="A" pin="T-" pad="2"/>
+<connect gate="A" pin="VCC" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="MANUFACTURER_PART_NUMBER" value="MAX31855KASA+" constant="no"/>
+<attribute name="VENDOR" value="Maxim Integrated Products" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="21-0041B_8-M" package="21-0041B_8-M">
+<connects>
+<connect gate="A" pin="!CS" pad="6"/>
+<connect gate="A" pin="DNC" pad="8"/>
+<connect gate="A" pin="GND" pad="1"/>
+<connect gate="A" pin="SCK" pad="5"/>
+<connect gate="A" pin="SO" pad="7"/>
+<connect gate="A" pin="T+" pad="3"/>
+<connect gate="A" pin="T-" pad="2"/>
+<connect gate="A" pin="VCC" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="MANUFACTURER_PART_NUMBER" value="MAX31855KASA+" constant="no"/>
+<attribute name="VENDOR" value="Maxim Integrated Products" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="21-0041B_8-L" package="21-0041B_8-L">
+<connects>
+<connect gate="A" pin="!CS" pad="6"/>
+<connect gate="A" pin="DNC" pad="8"/>
+<connect gate="A" pin="GND" pad="1"/>
+<connect gate="A" pin="SCK" pad="5"/>
+<connect gate="A" pin="SO" pad="7"/>
+<connect gate="A" pin="T+" pad="3"/>
+<connect gate="A" pin="T-" pad="2"/>
+<connect gate="A" pin="VCC" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="MANUFACTURER_PART_NUMBER" value="MAX31855KASA+" constant="no"/>
+<attribute name="VENDOR" value="Maxim Integrated Products" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="RESISTOR" prefix="R" uservalue="yes">
+<description>&lt;b&gt;Resistor&lt;/b&gt;
+Basic schematic elements and footprints for 0603, 1206, and PTH resistors.</description>
+<gates>
+<gate name="G$1" symbol="RESISTOR" x="0" y="0"/>
+</gates>
+<devices>
+<device name="0402" package="0402-RES">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
-<connect gate="G$1" pin="3" pad="3"/>
-<connect gate="G$1" pin="4" pad="4"/>
-<connect gate="G$1" pin="5" pad="5"/>
-<connect gate="G$1" pin="6" pad="6"/>
-<connect gate="G$1" pin="7" pad="7"/>
-<connect gate="G$1" pin="8" pad="8"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0603" package="0603-RES">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0603-RES" package="0603-RES">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0805-RES" package="0805">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="1206" package="1206">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="2010" package="R2010">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="2512" package="R2512">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="AXIAL-0.3" package="AXIAL-0.3">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="EZ" package="AXIAL-0.3EZ">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="KIT" package="AXIAL-0.3-KIT">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="PTH-1/2W" package="AXIAL-0.5">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="PTH-1/4W" package="AXIAL-0.4">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="PTH-1/4W-VERT" package="AXIAL-0.1">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="PTH-1/4W-VERT-KIT" package="AXIAL-0.1EZ">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="PTH-1/6W" package="1/6W-RES">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="PTH-1W" package="AXIAL-0.6">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="PTH-2W" package="AXIAL-0.8">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="10W" package="10W_RESISTOR_VISHAY">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="PWR163" package="PWR163">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="0001.2704.11">
+<description>&lt;b&gt; Schurter Surface Mount Ceramic Fuse &lt;/b&gt;
+&lt;br&gt;
+Current Rating: 1A
+&lt;br&gt;
+Voltage Rating AC: 250 VAC
+&lt;br&gt;
+Voltage Rating DC: 300 VDC
+&lt;br&gt;
+Dimensions: 5 mm x 20 mm
+&lt;br&gt;
+&lt;a href="http://www.mouser.com/ds/2/358/typ_SMD-SPT-46594.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<gates>
+<gate name="G$1" symbol="FUSE" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="5X20MM_FUSE">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="BATTERY_SPRING">
+<description>&lt;b&gt; Keystone Electronics Battery Spring Contact &lt;/b&gt;
+&lt;br&gt;
+&lt;a href="http://keyelco.com/userAssets/file/M65p17.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<gates>
+<gate name="G$1" symbol="MV" x="0" y="0" addlevel="always"/>
+</gates>
+<devices>
+<device name="_KEYSTONE5222" package="KEYSTONE5222">
+<connects>
+<connect gate="G$1" pin="S" pad="P$1"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="" package="KEYSTONE5203">
+<connects>
+<connect gate="G$1" pin="S" pad="P$1"/>
 </connects>
 <technologies>
 <technology name=""/>


### PR DESCRIPTION
Improves pad sizes for fuses, power resistor, and keystone 5222 spring. 
Adds LTC6811 part from LTC6804 part.
See [this PR](https://github.com/hytech-racing/circuits-2020/pull/31).