### PR TITLE
Watchdog Part Fix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,12 @@
 # Pull Request (PR) into Circuits-Support-2020
 
-***Your PR should not cause any merge conflicts, so please merge the `master` branch into your branch before submitting. It is your responsibility to ensure that the merge does not break something before submitting. [Here](https://guides.github.com/features/mastering-markdown/) is a good resource for markdown formatting as you fill out this template. Feel free to ask any electrical lead if you have any questions!***
+***Your PR should not cause any merge conflicts, so please merge the `master` branch into your branch before submitting. It is your responsibility to ensure that the merge does not break something before submitting. [Here](https://guides.github.com/features/mastering-markdown/) is a good resource for markdown formatting as you fill out this template. See this [example](https://github.com/hytech-racing/circuits-support-2020/pull/9). Feel free to ask any electrical lead if you have any questions! Delete this block when actually making your PR!***
+
+## Part Description
+*Describe the contents of the pull request. List all the devices you added. Also list any footprints or symbols you modified. If changing other supporting files, please give details on what those changes are.*
+
+## Additional Information
+*Put any datasheets per new device, information, and/or useful links here.*
 
 ## Checklist
 - [ ] Did you create any new schematics or boards?
@@ -10,9 +16,3 @@
 - - [ ] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
 - [ ] Did you fill out the below template?
 - [ ] Did you assign the right people for review (on the right)?
-
-## Part Description
-*Describe the contents of the pull request. List all the devices you added. Also list any footprints or symbols you modified. If changing other supporting files, please give details on what those changes are.*
-
-## Additional Information
-*Put any datasheets per new device, information and/or useful links here.*

--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -25623,7 +25623,7 @@ Dimensions: 5 mm x 20 mm
 </devices>
 </deviceset>
 <deviceset name="STWD100NYWY3F">
-<description>STWD100 Watchdog Timer (open-drain configuration)</description>
+<description>STWD100 Watchdog Timer (open-drain configuration) &lt;a href="https://www.st.com/resource/en/datasheet/stwd100.pdf"&gt;Datasheet&lt;/a&gt;</description>
 <gates>
 <gate name="G$1" symbol="STWD100" x="-7.62" y="7.62"/>
 </gates>
@@ -25643,7 +25643,7 @@ Dimensions: 5 mm x 20 mm
 </devices>
 </deviceset>
 <deviceset name="STWD100PYW83F">
-<description>STWD100 Watchdog Timer (push-pull configuration)</description>
+<description>STWD100 Watchdog Timer (push-pull configuration) &lt;a href="https://www.st.com/resource/en/datasheet/stwd100.pdf"&gt;Datasheet&lt;/a&gt;</description>
 <gates>
 <gate name="G$1" symbol="STWD100" x="-7.62" y="7.62"/>
 </gates>

--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.6.2">
+<eagle version="9.5.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -11584,7 +11584,212 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <circle x="0" y="0" radius="1.5" width="0.127" layer="40"/>
 <circle x="0" y="0" radius="1.5" width="0.127" layer="39"/>
 </package>
+<package name="QFP80P900X900X120-32N">
+<wire x1="3.4" y1="3.4" x2="3.4" y2="-3.4" width="0.1524" layer="21"/>
+<wire x1="3.4" y1="-3.4" x2="-3.4" y2="-3.4" width="0.1524" layer="21"/>
+<wire x1="-3.4" y1="-3.4" x2="-3.4" y2="3.4" width="0.1524" layer="21"/>
+<wire x1="-3.4" y1="3.4" x2="3.4" y2="3.4" width="0.1524" layer="21"/>
+<circle x="-2.7432" y="2.7432" radius="0.3592" width="0.1524" layer="21"/>
+<text x="-5.57938125" y="5.63088125" size="0.814375" layer="25">&gt;NAME</text>
+<text x="-5.52646875" y="-6.514559375" size="0.81336875" layer="27">&gt;VALUE</text>
+<rectangle x1="-4.49693125" y1="2.571590625" x2="-3.506" y2="3.0286" layer="51"/>
+<rectangle x1="-4.50498125" y1="1.7747" x2="-3.506" y2="2.2286" layer="51"/>
+<rectangle x1="-4.500090625" y1="0.97215625" x2="-3.506" y2="1.4286" layer="51"/>
+<rectangle x1="-4.50036875" y1="0.17154375" x2="-3.506" y2="0.6286" layer="51"/>
+<rectangle x1="-4.50256875" y1="-0.629434375" x2="-3.506" y2="-0.1714" layer="51"/>
+<rectangle x1="-4.50186875" y1="-1.43028125" x2="-3.506" y2="-0.9714" layer="51"/>
+<rectangle x1="-4.50138125" y1="-2.23096875" x2="-3.506" y2="-1.7714" layer="51"/>
+<rectangle x1="-4.50128125" y1="-3.03175" x2="-3.506" y2="-2.5714" layer="51"/>
+<rectangle x1="-3.03458125" y1="-4.50548125" x2="-2.5714" y2="-3.506" layer="51"/>
+<rectangle x1="-2.230459375" y1="-4.50035" x2="-1.7714" y2="-3.506" layer="51"/>
+<rectangle x1="-1.43093125" y1="-4.503940625" x2="-0.9714" y2="-3.506" layer="51"/>
+<rectangle x1="-0.628771875" y1="-4.497840625" x2="-0.1714" y2="-3.506" layer="51"/>
+<rectangle x1="0.1716" y1="-4.501840625" x2="0.6286" y2="-3.506" layer="51"/>
+<rectangle x1="0.971784375" y1="-4.49838125" x2="1.4286" y2="-3.506" layer="51"/>
+<rectangle x1="1.77431875" y1="-4.504009375" x2="2.2286" y2="-3.506" layer="51"/>
+<rectangle x1="2.57515" y1="-4.50315" x2="3.0286" y2="-3.506" layer="51"/>
+<rectangle x1="3.506709375" y1="-3.029209375" x2="4.4966" y2="-2.5714" layer="51"/>
+<rectangle x1="3.51286875" y1="-2.23296875" x2="4.4966" y2="-1.7714" layer="51"/>
+<rectangle x1="3.51128125" y1="-1.43075" x2="4.4966" y2="-0.9714" layer="51"/>
+<rectangle x1="3.509259375" y1="-0.629184375" x2="4.4966" y2="-0.1714" layer="51"/>
+<rectangle x1="3.50885" y1="0.1715375" x2="4.4966" y2="0.6286" layer="51"/>
+<rectangle x1="3.51123125" y1="0.972846875" x2="4.4966" y2="1.4286" layer="51"/>
+<rectangle x1="3.51065" y1="1.77375" x2="4.4966" y2="2.2286" layer="51"/>
+<rectangle x1="3.511440625" y1="2.575390625" x2="4.4966" y2="3.0286" layer="51"/>
+<rectangle x1="2.57641875" y1="3.51285" x2="3.0286" y2="4.4966" layer="51"/>
+<rectangle x1="1.77408125" y1="3.511309375" x2="2.2286" y2="4.4966" layer="51"/>
+<rectangle x1="0.972196875" y1="3.50888125" x2="1.4286" y2="4.4966" layer="51"/>
+<rectangle x1="0.17140625" y1="3.506109375" x2="0.6286" y2="4.4966" layer="51"/>
+<rectangle x1="-0.62981875" y1="3.512790625" x2="-0.1714" y2="4.4966" layer="51"/>
+<rectangle x1="-1.42951875" y1="3.50826875" x2="-0.9714" y2="4.4966" layer="51"/>
+<rectangle x1="-2.23255" y1="3.51221875" x2="-1.7714" y2="4.4966" layer="51"/>
+<rectangle x1="-3.0316" y1="3.50946875" x2="-2.5714" y2="4.4966" layer="51"/>
+<wire x1="-5.5" y1="-5.5" x2="5.5" y2="-5.5" width="0.05" layer="39"/>
+<wire x1="5.5" y1="-5.5" x2="5.5" y2="5.5" width="0.05" layer="39"/>
+<wire x1="5.5" y1="5.5" x2="-5.5" y2="5.5" width="0.05" layer="39"/>
+<wire x1="-5.5" y1="5.5" x2="-5.5" y2="-5.5" width="0.05" layer="39"/>
+<circle x="-4.5" y="3.75" radius="0.254" width="0" layer="21"/>
+<smd name="1" x="-4.3" y="2.8" dx="1.5" dy="0.55" layer="1"/>
+<smd name="2" x="-4.3" y="2" dx="1.5" dy="0.55" layer="1"/>
+<smd name="3" x="-4.3" y="1.2" dx="1.5" dy="0.55" layer="1"/>
+<smd name="4" x="-4.3" y="0.4" dx="1.5" dy="0.55" layer="1"/>
+<smd name="5" x="-4.3" y="-0.4" dx="1.5" dy="0.55" layer="1"/>
+<smd name="6" x="-4.3" y="-1.2" dx="1.5" dy="0.55" layer="1"/>
+<smd name="7" x="-4.3" y="-2" dx="1.5" dy="0.55" layer="1"/>
+<smd name="8" x="-4.3" y="-2.8" dx="1.5" dy="0.55" layer="1"/>
+<smd name="9" x="-2.8" y="-4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="10" x="-2" y="-4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="11" x="-1.2" y="-4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="12" x="-0.4" y="-4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="13" x="0.4" y="-4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="14" x="1.2" y="-4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="15" x="2" y="-4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="16" x="2.8" y="-4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="17" x="4.3" y="-2.8" dx="1.5" dy="0.55" layer="1"/>
+<smd name="18" x="4.3" y="-2" dx="1.5" dy="0.55" layer="1"/>
+<smd name="19" x="4.3" y="-1.2" dx="1.5" dy="0.55" layer="1"/>
+<smd name="20" x="4.3" y="-0.4" dx="1.5" dy="0.55" layer="1"/>
+<smd name="21" x="4.3" y="0.4" dx="1.5" dy="0.55" layer="1"/>
+<smd name="22" x="4.3" y="1.2" dx="1.5" dy="0.55" layer="1"/>
+<smd name="23" x="4.3" y="2" dx="1.5" dy="0.55" layer="1"/>
+<smd name="24" x="4.3" y="2.8" dx="1.5" dy="0.55" layer="1"/>
+<smd name="25" x="2.8" y="4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="26" x="2" y="4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="27" x="1.2" y="4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="28" x="0.4" y="4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="29" x="-0.4" y="4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="30" x="-1.2" y="4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="31" x="-2" y="4.3" dx="0.55" dy="1.5" layer="1"/>
+<smd name="32" x="-2.8" y="4.3" dx="0.55" dy="1.5" layer="1"/>
+</package>
+<package name="2X03" urn="urn:adsk.eagle:footprint:22348/1" locally_modified="yes">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<wire x1="-3.81" y1="-1.905" x2="-3.175" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="-2.54" x2="-1.27" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="-1.905" x2="-0.635" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="-2.54" x2="1.27" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="-1.905" x2="-3.81" y2="1.905" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="1.905" x2="-3.175" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="2.54" x2="-1.905" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="2.54" x2="-1.27" y2="1.905" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="1.905" x2="-0.635" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="2.54" x2="0.635" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="2.54" x2="1.27" y2="1.905" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="1.905" x2="-1.27" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="1.905" x2="1.27" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="-2.54" x2="0.635" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="-2.54" x2="-1.905" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="-1.905" x2="1.905" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="-2.54" x2="3.81" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="1.905" x2="1.905" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="2.54" x2="3.175" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="2.54" x2="3.81" y2="1.905" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="1.905" x2="3.81" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="-2.54" x2="3.175" y2="-2.54" width="0.1524" layer="21"/>
+<pad name="1" x="-2.54" y="-1.27" drill="1.016" shape="square" stop="no"/>
+<pad name="2" x="-2.54" y="1.27" drill="1.016" stop="no"/>
+<pad name="3" x="0" y="-1.27" drill="1.016" stop="no"/>
+<pad name="4" x="0" y="1.27" drill="1.016" stop="no"/>
+<pad name="5" x="2.54" y="-1.27" drill="1.016" stop="no"/>
+<pad name="6" x="2.54" y="1.27" drill="1.016" stop="no"/>
+<text x="-3.81" y="3.175" size="1.27" layer="25" font="vector">&gt;NAME</text>
+<text x="-3.81" y="-4.445" size="1.27" layer="27" font="vector">&gt;VALUE</text>
+<rectangle x1="-2.794" y1="-1.524" x2="-2.286" y2="-1.016" layer="51"/>
+<rectangle x1="-2.794" y1="1.016" x2="-2.286" y2="1.524" layer="51"/>
+<rectangle x1="-0.254" y1="1.016" x2="0.254" y2="1.524" layer="51"/>
+<rectangle x1="-0.254" y1="-1.524" x2="0.254" y2="-1.016" layer="51"/>
+<rectangle x1="2.286" y1="1.016" x2="2.794" y2="1.524" layer="51"/>
+<rectangle x1="2.286" y1="-1.524" x2="2.794" y2="-1.016" layer="51"/>
+<circle x="-4.445" y="-1.27" radius="0.1" width="0.254" layer="21"/>
+</package>
+<package name="SOT363">
+<description>SOT363 Package</description>
+<smd name="P$1" x="-0.9652" y="0.6731" dx="0.6096" dy="0.4318" layer="1"/>
+<smd name="P$2" x="-0.9652" y="0.022859375" dx="0.6096" dy="0.4318" layer="1"/>
+<smd name="P$3" x="-0.9652" y="-0.62738125" dx="0.6096" dy="0.4318" layer="1"/>
+<smd name="P$4" x="0.929640625" y="0.6731" dx="0.6096" dy="0.4318" layer="1"/>
+<smd name="P$5" x="0.929640625" y="0.022859375" dx="0.6096" dy="0.4318" layer="1"/>
+<smd name="P$6" x="0.929640625" y="-0.62738125" dx="0.6096" dy="0.4318" layer="1"/>
+<wire x1="-0.5588" y1="0.9398" x2="-0.5588" y2="-0.889" width="0.127" layer="25"/>
+<wire x1="-0.5588" y1="-0.889" x2="0.5334" y2="-0.889" width="0.127" layer="25"/>
+<wire x1="0.5334" y1="-0.889" x2="0.5334" y2="0.9398" width="0.127" layer="25"/>
+<wire x1="0.5334" y1="0.9398" x2="-0.5588" y2="0.9398" width="0.127" layer="25"/>
+<circle x="-0.2286" y="0.6604" radius="0.127" width="0.127" layer="25"/>
+<text x="-1.905" y="1.27" size="0.8128" layer="25">&gt;NAME</text>
+</package>
+<package name="CAT16-*8">
+<smd name="P$1" x="-2.8" y="-0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$2" x="-2" y="-0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$3" x="-1.2" y="-0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$4" x="-0.4" y="-0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$5" x="0.4" y="-0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$6" x="1.2" y="-0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$7" x="2" y="-0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$8" x="2.8" y="-0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$9" x="2.8" y="0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$10" x="2" y="0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$11" x="1.2" y="0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$12" x="0.4" y="0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$13" x="-0.4" y="0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$14" x="-1.2" y="0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$15" x="-2" y="0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$16" x="-2.8" y="0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<wire x1="-3.3" y1="0.9" x2="3.3" y2="0.9" width="0.127" layer="21"/>
+<wire x1="3.3" y1="0.9" x2="3.3" y2="-0.9" width="0.127" layer="21"/>
+<wire x1="3.3" y1="-0.9" x2="-3.3" y2="-0.9" width="0.127" layer="21"/>
+<wire x1="-3.3" y1="-0.9" x2="-3.3" y2="0.9" width="0.127" layer="21"/>
+<text x="-2.7" y="1.8" size="1.016" layer="25" font="vector">&gt;NAME</text>
+<text x="-2.7" y="-1.8" size="1.016" layer="27" font="vector" align="top-left">&gt;VALUE</text>
+<wire x1="-2.8" y1="0.2" x2="-2.8" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="-2" y1="0.2" x2="-2" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="-1.2" y1="0.2" x2="-1.2" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="-0.4" y1="0.2" x2="-0.4" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="0.4" y1="0.2" x2="0.4" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="1.2" y1="0.2" x2="1.2" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="2" y1="0.2" x2="2" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="2.8" y1="0.2" x2="2.8" y2="-0.2" width="0.127" layer="51"/>
+</package>
+<package name="CAT16-*4">
+<smd name="P$1" x="-1.2" y="-0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$2" x="-0.4" y="-0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$3" x="0.4" y="-0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$4" x="1.2" y="-0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$5" x="1.2" y="0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$6" x="0.4" y="0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$7" x="-0.4" y="0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<smd name="P$8" x="-1.2" y="0.825" dx="0.95" dy="0.45" layer="1" rot="R90"/>
+<wire x1="-1.7" y1="0.9" x2="1.7" y2="0.9" width="0.127" layer="21"/>
+<wire x1="1.7" y1="0.9" x2="1.7" y2="-0.9" width="0.127" layer="21"/>
+<wire x1="1.7" y1="-0.9" x2="-1.7" y2="-0.9" width="0.127" layer="21"/>
+<wire x1="-1.7" y1="-0.9" x2="-1.7" y2="0.9" width="0.127" layer="21"/>
+<text x="-1.1" y="1.8" size="1.016" layer="25" font="vector">&gt;NAME</text>
+<text x="-1.1" y="-1.8" size="1.016" layer="27" font="vector" align="top-left">&gt;VALUE</text>
+<wire x1="-1.2" y1="0.2" x2="-1.2" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="-0.4" y1="0.2" x2="-0.4" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="0.4" y1="0.2" x2="0.4" y2="-0.2" width="0.127" layer="51"/>
+<wire x1="1.2" y1="0.2" x2="1.2" y2="-0.2" width="0.127" layer="51"/>
+</package>
+<package name="ABM3B">
+<wire x1="0" y1="3.5814" x2="0" y2="0" width="0.127" layer="25"/>
+<wire x1="0" y1="0" x2="5.8674" y2="0" width="0.127" layer="25"/>
+<wire x1="5.8674" y1="0" x2="5.8674" y2="3.5814" width="0.127" layer="25"/>
+<wire x1="5.8674" y1="3.5814" x2="0" y2="3.5814" width="0.127" layer="25"/>
+<smd name="P$1" x="0.9017" y="2.9845" dx="1.8034" dy="1.1938" layer="1"/>
+<smd name="P$2" x="4.9657" y="2.9845" dx="1.8034" dy="1.1938" layer="1"/>
+<smd name="P$4" x="0.9017" y="0.5969" dx="1.8034" dy="1.1938" layer="1"/>
+<smd name="P$3" x="4.9657" y="0.5969" dx="1.8034" dy="1.1938" layer="1"/>
+<text x="-0.254" y="3.81" size="1.27" layer="25">&gt;NAME</text>
+<text x="-0.254" y="-1.524" size="1.27" layer="27">&gt;VALUE</text>
+</package>
 </packages>
+<packages3d>
+<package3d name="2X03" urn="urn:adsk.eagle:package:22462/2" type="model">
+<description>PIN HEADER</description>
+<packageinstances>
+<packageinstance name="2X03"/>
+</packageinstances>
+</package3d>
+</packages3d>
 <symbols>
 <symbol name="ARDUINO_NANO">
 <pin name="3.3V" x="-2.54" y="40.64" visible="pin" length="short"/>
@@ -16187,6 +16392,134 @@ Demo Board</text>
 <wire x1="22.86" y1="2.54" x2="7.62" y2="2.54" width="0.1524" layer="94"/>
 <text x="10.5156" y="6.5786" size="2.0828" layer="95" ratio="6" rot="SR0">&gt;Name</text>
 <text x="9.8806" y="4.0386" size="2.0828" layer="96" ratio="6" rot="SR0">&gt;Value</text>
+</symbol>
+<symbol name="ATMEGA328P-AU">
+<wire x1="10.16" y1="27.94" x2="10.16" y2="-27.94" width="0.254" layer="94"/>
+<wire x1="10.16" y1="-27.94" x2="-10.16" y2="-27.94" width="0.254" layer="94"/>
+<wire x1="-10.16" y1="-27.94" x2="-10.16" y2="27.94" width="0.254" layer="94"/>
+<wire x1="-10.16" y1="27.94" x2="10.16" y2="27.94" width="0.254" layer="94"/>
+<text x="-10.1755" y="29.2546" size="2.54388125" layer="95">&gt;NAME</text>
+<text x="-10.1669" y="-31.7714" size="2.54171875" layer="96">&gt;VALUE</text>
+<pin name="VCC" x="15.24" y="22.86" length="middle" direction="pwr" rot="R180"/>
+<pin name="GND" x="15.24" y="-25.4" length="middle" direction="pwr" rot="R180"/>
+<pin name="PB0" x="-15.24" y="17.78" length="middle"/>
+<pin name="PB1" x="-15.24" y="15.24" length="middle"/>
+<pin name="PB2" x="-15.24" y="12.7" length="middle"/>
+<pin name="PB3" x="-15.24" y="10.16" length="middle"/>
+<pin name="PB4" x="-15.24" y="7.62" length="middle"/>
+<pin name="PB5" x="-15.24" y="5.08" length="middle"/>
+<pin name="PB6" x="-15.24" y="2.54" length="middle"/>
+<pin name="PB7" x="-15.24" y="0" length="middle"/>
+<pin name="PC0" x="-15.24" y="-5.08" length="middle"/>
+<pin name="PC1" x="-15.24" y="-7.62" length="middle"/>
+<pin name="PC2" x="-15.24" y="-10.16" length="middle"/>
+<pin name="PC3" x="-15.24" y="-12.7" length="middle"/>
+<pin name="PC4" x="-15.24" y="-15.24" length="middle"/>
+<pin name="PC5" x="-15.24" y="-17.78" length="middle"/>
+<pin name="PC6/!RESET" x="-15.24" y="-20.32" length="middle"/>
+<pin name="PD0" x="15.24" y="17.78" length="middle" rot="R180"/>
+<pin name="PD1" x="15.24" y="15.24" length="middle" rot="R180"/>
+<pin name="PD2" x="15.24" y="12.7" length="middle" rot="R180"/>
+<pin name="PD3" x="15.24" y="10.16" length="middle" rot="R180"/>
+<pin name="PD4" x="15.24" y="7.62" length="middle" rot="R180"/>
+<pin name="PD5" x="15.24" y="5.08" length="middle" rot="R180"/>
+<pin name="PD6" x="15.24" y="2.54" length="middle" rot="R180"/>
+<pin name="PD7" x="15.24" y="0" length="middle" rot="R180"/>
+<pin name="AREF" x="-15.24" y="22.86" length="middle" direction="in"/>
+<pin name="AVCC" x="15.24" y="25.4" length="middle" direction="pwr" rot="R180"/>
+<pin name="ADC6" x="15.24" y="-5.08" length="middle" rot="R180"/>
+<pin name="ADC7" x="15.24" y="-7.62" length="middle" rot="R180"/>
+</symbol>
+<symbol name="CONN_03X2">
+<description>&lt;h3&gt;6 Pin Connection&lt;/h3&gt;
+3x2 pin layout</description>
+<wire x1="3.81" y1="-5.08" x2="-3.81" y2="-5.08" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="-2.54" x2="2.54" y2="-2.54" width="0.6096" layer="94"/>
+<wire x1="-3.81" y1="5.08" x2="-3.81" y2="-5.08" width="0.4064" layer="94"/>
+<wire x1="3.81" y1="-5.08" x2="3.81" y2="5.08" width="0.4064" layer="94"/>
+<wire x1="-3.81" y1="5.08" x2="3.81" y2="5.08" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="2.54" x2="2.54" y2="2.54" width="0.6096" layer="94"/>
+<wire x1="1.27" y1="0" x2="2.54" y2="0" width="0.6096" layer="94"/>
+<wire x1="-1.27" y1="-2.54" x2="-2.54" y2="-2.54" width="0.6096" layer="94"/>
+<wire x1="-1.27" y1="2.54" x2="-2.54" y2="2.54" width="0.6096" layer="94"/>
+<wire x1="-1.27" y1="0" x2="-2.54" y2="0" width="0.6096" layer="94"/>
+<text x="-3.81" y="-7.366" size="1.778" layer="96">&gt;VALUE</text>
+<text x="-3.81" y="5.588" size="1.778" layer="95">&gt;NAME</text>
+<pin name="6" x="7.62" y="-2.54" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="4" x="7.62" y="0" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="2" x="7.62" y="2.54" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="5" x="-7.62" y="-2.54" visible="pad" length="middle" direction="pas" swaplevel="1"/>
+<pin name="3" x="-7.62" y="0" visible="pad" length="middle" direction="pas" swaplevel="1"/>
+<pin name="1" x="-7.62" y="2.54" visible="pad" length="middle" direction="pas" swaplevel="1"/>
+</symbol>
+<symbol name="ZENER_ARRAY_3">
+<description>Array of 3 independent zener diodes.</description>
+<wire x1="7.62" y1="3.302" x2="7.62" y2="2.54" width="0.254" layer="94"/>
+<polygon width="0.254" layer="94">
+<vertex x="5.08" y="3.81"/>
+<vertex x="5.08" y="1.27"/>
+<vertex x="7.62" y="2.54"/>
+</polygon>
+<wire x1="7.62" y1="2.54" x2="7.62" y2="1.778" width="0.254" layer="94"/>
+<wire x1="7.112" y1="3.81" x2="7.62" y2="3.302" width="0.254" layer="94"/>
+<wire x1="7.62" y1="1.778" x2="8.128" y2="1.27" width="0.254" layer="94"/>
+<wire x1="7.62" y1="8.382" x2="7.62" y2="7.62" width="0.254" layer="94"/>
+<polygon width="0.254" layer="94">
+<vertex x="5.08" y="8.89"/>
+<vertex x="5.08" y="6.35"/>
+<vertex x="7.62" y="7.62"/>
+</polygon>
+<wire x1="7.62" y1="7.62" x2="7.62" y2="6.858" width="0.254" layer="94"/>
+<wire x1="7.112" y1="8.89" x2="7.62" y2="8.382" width="0.254" layer="94"/>
+<wire x1="7.62" y1="6.858" x2="8.128" y2="6.35" width="0.254" layer="94"/>
+<wire x1="7.62" y1="13.462" x2="7.62" y2="12.7" width="0.254" layer="94"/>
+<polygon width="0.254" layer="94">
+<vertex x="5.08" y="13.97"/>
+<vertex x="5.08" y="11.43"/>
+<vertex x="7.62" y="12.7"/>
+</polygon>
+<wire x1="7.62" y1="12.7" x2="7.62" y2="11.938" width="0.254" layer="94"/>
+<wire x1="7.112" y1="13.97" x2="7.62" y2="13.462" width="0.254" layer="94"/>
+<wire x1="7.62" y1="11.938" x2="8.128" y2="11.43" width="0.254" layer="94"/>
+<wire x1="0" y1="15.24" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="12.7" y2="0" width="0.254" layer="94"/>
+<wire x1="12.7" y1="0" x2="12.7" y2="15.24" width="0.254" layer="94"/>
+<wire x1="12.7" y1="15.24" x2="0" y2="15.24" width="0.254" layer="94"/>
+<pin name="A1" x="-2.54" y="12.7" visible="off" length="middle"/>
+<pin name="A2" x="-2.54" y="7.62" visible="off" length="middle"/>
+<pin name="A3" x="-2.54" y="2.54" visible="off" length="middle"/>
+<pin name="C3" x="15.24" y="2.54" visible="off" length="middle" rot="R180"/>
+<pin name="C2" x="15.24" y="7.62" visible="off" length="middle" rot="R180"/>
+<pin name="C1" x="15.24" y="12.7" visible="off" length="middle" rot="R180"/>
+<wire x1="2.54" y1="12.7" x2="5.08" y2="12.7" width="0.1524" layer="94"/>
+<wire x1="7.62" y1="12.7" x2="10.16" y2="12.7" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="7.62" x2="5.08" y2="7.62" width="0.1524" layer="94"/>
+<wire x1="7.62" y1="7.62" x2="10.16" y2="7.62" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="2.54" x2="5.08" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="7.62" y1="2.54" x2="10.16" y2="2.54" width="0.1524" layer="94"/>
+<text x="0" y="16.002" size="1.778" layer="95">&gt;NAME</text>
+<text x="0" y="-2.54" size="1.778" layer="95">&gt;VALUE</text>
+<text x="0.508" y="12.954" size="1.27" layer="96">A1</text>
+<text x="0.508" y="7.874" size="1.27" layer="96">A2</text>
+<text x="0.508" y="2.794" size="1.27" layer="96">A3</text>
+<text x="10.16" y="12.954" size="1.27" layer="96">C1</text>
+<text x="10.16" y="7.874" size="1.27" layer="96">C2</text>
+<text x="10.16" y="2.794" size="1.27" layer="96">C3</text>
+</symbol>
+<symbol name="RESISTOR-1">
+<wire x1="-2.54" y1="0" x2="-2.159" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="-2.159" y1="1.016" x2="-1.524" y2="-1.016" width="0.1524" layer="94"/>
+<wire x1="-1.524" y1="-1.016" x2="-0.889" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="-0.889" y1="1.016" x2="-0.254" y2="-1.016" width="0.1524" layer="94"/>
+<wire x1="-0.254" y1="-1.016" x2="0.381" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="0.381" y1="1.016" x2="1.016" y2="-1.016" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="-1.016" x2="1.651" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="1.651" y1="1.016" x2="2.286" y2="-1.016" width="0.1524" layer="94"/>
+<wire x1="2.286" y1="-1.016" x2="2.54" y2="0" width="0.1524" layer="94"/>
+<text x="0" y="1.524" size="1.778" layer="95" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-1.524" size="1.778" layer="96" align="top-center">&gt;VALUE</text>
+<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
 </symbol>
 </symbols>
 <devicesets>
@@ -24949,6 +25282,255 @@ Dimensions: 5 mm x 20 mm
 </device>
 </devices>
 </deviceset>
+<deviceset name="ATMEGA328P-AU" prefix="U">
+<description>ATmega Series 20 MHz 32 KB Flash 2 KB SRAM 8-Bit Microcontroller - TQFP-32</description>
+<gates>
+<gate name="G$1" symbol="ATMEGA328P-AU" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="QFP80P900X900X120-32N">
+<connects>
+<connect gate="G$1" pin="ADC6" pad="19"/>
+<connect gate="G$1" pin="ADC7" pad="22"/>
+<connect gate="G$1" pin="AREF" pad="20"/>
+<connect gate="G$1" pin="AVCC" pad="18"/>
+<connect gate="G$1" pin="GND" pad="3 5 21"/>
+<connect gate="G$1" pin="PB0" pad="12"/>
+<connect gate="G$1" pin="PB1" pad="13"/>
+<connect gate="G$1" pin="PB2" pad="14"/>
+<connect gate="G$1" pin="PB3" pad="15"/>
+<connect gate="G$1" pin="PB4" pad="16"/>
+<connect gate="G$1" pin="PB5" pad="17"/>
+<connect gate="G$1" pin="PB6" pad="7"/>
+<connect gate="G$1" pin="PB7" pad="8"/>
+<connect gate="G$1" pin="PC0" pad="23"/>
+<connect gate="G$1" pin="PC1" pad="24"/>
+<connect gate="G$1" pin="PC2" pad="25"/>
+<connect gate="G$1" pin="PC3" pad="26"/>
+<connect gate="G$1" pin="PC4" pad="27"/>
+<connect gate="G$1" pin="PC5" pad="28"/>
+<connect gate="G$1" pin="PC6/!RESET" pad="29"/>
+<connect gate="G$1" pin="PD0" pad="30"/>
+<connect gate="G$1" pin="PD1" pad="31"/>
+<connect gate="G$1" pin="PD2" pad="32"/>
+<connect gate="G$1" pin="PD3" pad="1"/>
+<connect gate="G$1" pin="PD4" pad="2"/>
+<connect gate="G$1" pin="PD5" pad="9"/>
+<connect gate="G$1" pin="PD6" pad="10"/>
+<connect gate="G$1" pin="PD7" pad="11"/>
+<connect gate="G$1" pin="VCC" pad="4 6"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="AVAILABILITY" value="Unavailable"/>
+<attribute name="DESCRIPTION" value=" AVR AVR® ATmega Microcontroller IC 8-Bit 20MHz 32KB _16K x 16_ FLASH 32-TQFP _7x7_ "/>
+<attribute name="MF" value="Microchip"/>
+<attribute name="MP" value="ATMEGA328P-AU"/>
+<attribute name="PACKAGE" value="TQFP-32 Microchip"/>
+<attribute name="PRICE" value="None"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="AVR-ISP-HEADER" prefix="J">
+<description>&lt;p&gt;AVR ISP 6-pin Header&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://en.wikipedia.org/wiki/In-system_programming"&gt;Reference&lt;/a&gt;&lt;/p&gt;</description>
+<gates>
+<gate name="G$1" symbol="CONN_03X2" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="2X03">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:22462/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="DIGIKEY" value="S2011EC-03-ND"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="MMBZ5245BTS-7-F">
+<description>15V Zener Diode Array 3 Independent with SOT363 footprint.
+
+&lt;p&gt;&lt;a href="https://www.mouser.com/datasheet/2/115/ds30184-1382386.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;</description>
+<gates>
+<gate name="G$1" symbol="ZENER_ARRAY_3" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="SOT363">
+<connects>
+<connect gate="G$1" pin="A1" pad="P$1"/>
+<connect gate="G$1" pin="A2" pad="P$2"/>
+<connect gate="G$1" pin="A3" pad="P$3"/>
+<connect gate="G$1" pin="C1" pad="P$4"/>
+<connect gate="G$1" pin="C2" pad="P$5"/>
+<connect gate="G$1" pin="C3" pad="P$6"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="VOLTAGE" value="15V"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="CAT16-*8" prefix="R" uservalue="yes">
+<description>&lt;p&gt;Bourns CAT16 series 8x 1% or 5% resistor array size 2506&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.bourns.com/docs/Product-Datasheets/CATCAY.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;
+
+&lt;p&gt;Options:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;CAT16-F8: 1% tolerance&lt;/li&gt;
+&lt;li&gt;CAT16-J8: 5% tolerance&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;Alternative: CTS Resistor Products 742C163 series&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.ctscorp.com/wp-content/uploads/74x.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;</description>
+<gates>
+<gate name="_1" symbol="RESISTOR-1" x="0" y="0"/>
+<gate name="_2" symbol="RESISTOR-1" x="0" y="-7.62"/>
+<gate name="_3" symbol="RESISTOR-1" x="0" y="-15.24"/>
+<gate name="_4" symbol="RESISTOR-1" x="0" y="-22.86"/>
+<gate name="_5" symbol="RESISTOR-1" x="0" y="-30.48"/>
+<gate name="_6" symbol="RESISTOR-1" x="0" y="-38.1"/>
+<gate name="_7" symbol="RESISTOR-1" x="0" y="-45.72"/>
+<gate name="_8" symbol="RESISTOR-1" x="0" y="-53.34"/>
+</gates>
+<devices>
+<device name="_5%" package="CAT16-*8">
+<connects>
+<connect gate="_1" pin="1" pad="P$1"/>
+<connect gate="_1" pin="2" pad="P$16"/>
+<connect gate="_2" pin="1" pad="P$2"/>
+<connect gate="_2" pin="2" pad="P$15"/>
+<connect gate="_3" pin="1" pad="P$3"/>
+<connect gate="_3" pin="2" pad="P$14"/>
+<connect gate="_4" pin="1" pad="P$4"/>
+<connect gate="_4" pin="2" pad="P$13"/>
+<connect gate="_5" pin="1" pad="P$5"/>
+<connect gate="_5" pin="2" pad="P$12"/>
+<connect gate="_6" pin="1" pad="P$6"/>
+<connect gate="_6" pin="2" pad="P$11"/>
+<connect gate="_7" pin="1" pad="P$7"/>
+<connect gate="_7" pin="2" pad="P$10"/>
+<connect gate="_8" pin="1" pad="P$8"/>
+<connect gate="_8" pin="2" pad="P$9"/>
+</connects>
+<technologies>
+<technology name="J"/>
+</technologies>
+</device>
+<device name="_1%" package="CAT16-*8">
+<connects>
+<connect gate="_1" pin="1" pad="P$1"/>
+<connect gate="_1" pin="2" pad="P$16"/>
+<connect gate="_2" pin="1" pad="P$2"/>
+<connect gate="_2" pin="2" pad="P$15"/>
+<connect gate="_3" pin="1" pad="P$3"/>
+<connect gate="_3" pin="2" pad="P$14"/>
+<connect gate="_4" pin="1" pad="P$4"/>
+<connect gate="_4" pin="2" pad="P$13"/>
+<connect gate="_5" pin="1" pad="P$5"/>
+<connect gate="_5" pin="2" pad="P$12"/>
+<connect gate="_6" pin="1" pad="P$6"/>
+<connect gate="_6" pin="2" pad="P$11"/>
+<connect gate="_7" pin="1" pad="P$7"/>
+<connect gate="_7" pin="2" pad="P$10"/>
+<connect gate="_8" pin="1" pad="P$8"/>
+<connect gate="_8" pin="2" pad="P$9"/>
+</connects>
+<technologies>
+<technology name="F"/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="CAT16-*4" prefix="R" uservalue="yes">
+<description>&lt;p&gt;Bourns CAT16 series 4x 1% or 5% resistor array size 1206&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.bourns.com/docs/Product-Datasheets/CATCAY.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;
+
+&lt;p&gt;Options:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;CAT16-F4: 1% tolerance&lt;/li&gt;
+&lt;li&gt;CAT16-J4: 5% tolerance&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;Alternatives:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;CTS Resistor Products 742C083 series - &lt;a href="https://www.ctscorp.com/wp-content/uploads/74x.pdf"&gt;Datasheet&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;Panasonic EXBV8 series - &lt;a href="https://industrial.panasonic.com/cdbs/www-data/pdf/AOC0000/AOC0000C14.pdf"&gt;Datasheet&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;Yageo TC164 series - &lt;a href="https://www.yageo.com/upload/media/product/productsearch/datasheet/rchip/PYu-YC_TC_group_51_RoHS_L_9.pdf"&gt;Datasheet&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;</description>
+<gates>
+<gate name="_1" symbol="RESISTOR-1" x="0" y="0"/>
+<gate name="_2" symbol="RESISTOR-1" x="0" y="-7.62"/>
+<gate name="_3" symbol="RESISTOR-1" x="0" y="-15.24"/>
+<gate name="_4" symbol="RESISTOR-1" x="0" y="-22.86"/>
+</gates>
+<devices>
+<device name="_5%" package="CAT16-*4">
+<connects>
+<connect gate="_1" pin="1" pad="P$1"/>
+<connect gate="_1" pin="2" pad="P$8"/>
+<connect gate="_2" pin="1" pad="P$2"/>
+<connect gate="_2" pin="2" pad="P$7"/>
+<connect gate="_3" pin="1" pad="P$3"/>
+<connect gate="_3" pin="2" pad="P$6"/>
+<connect gate="_4" pin="1" pad="P$4"/>
+<connect gate="_4" pin="2" pad="P$5"/>
+</connects>
+<technologies>
+<technology name="J"/>
+</technologies>
+</device>
+<device name="_1%" package="CAT16-*4">
+<connects>
+<connect gate="_1" pin="1" pad="P$1"/>
+<connect gate="_1" pin="2" pad="P$8"/>
+<connect gate="_2" pin="1" pad="P$2"/>
+<connect gate="_2" pin="2" pad="P$7"/>
+<connect gate="_3" pin="1" pad="P$3"/>
+<connect gate="_3" pin="2" pad="P$6"/>
+<connect gate="_4" pin="1" pad="P$4"/>
+<connect gate="_4" pin="2" pad="P$5"/>
+</connects>
+<technologies>
+<technology name="F"/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="ABM3B" uservalue="yes">
+<description>ABM3B ceramic SMD crystal. 
+&lt;p&gt;&lt;a href="https://www.mouser.com/datasheet/2/3/abm3b-39910.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;</description>
+<gates>
+<gate name="G$1" symbol="Q-SHIELD2" x="2.54" y="0"/>
+</gates>
+<devices>
+<device name="" package="ABM3B">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+<connect gate="G$1" pin="3" pad="P$3"/>
+<connect gate="G$1" pin="4" pad="P$4"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
 </devicesets>
 </library>
 </drawing>
@@ -24961,6 +25543,11 @@ which will not be processed correctly with this version.
 Since Version 8.3, EAGLE supports URNs for individual library
 assets (packages, symbols, and devices). The URNs of those assets
 will not be understood (or retained) with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports the association of 3D packages
+with devices in libraries, schematics, and board files. Those 3D
+packages will not be understood (or retained) with this version.
 </note>
 </compatibility>
 </eagle>

--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -14136,7 +14136,8 @@ DC/DC</text>
 <pin name="EN" x="-12.7" y="-5.08" length="middle"/>
 <pin name="WDI" x="12.7" y="-5.08" length="middle" rot="R180"/>
 <pin name="VCC" x="12.7" y="5.08" length="middle" rot="R180"/>
-<text x="-7.62" y="10.16" size="1.778" layer="95">STWD100</text>
+<text x="-7.62" y="-10.16" size="1.778" layer="96" align="top-left">&gt;VALUE</text>
+<text x="-7.62" y="10.16" size="1.778" layer="95">&gt;NAME</text>
 </symbol>
 <symbol name="JUMPER">
 <wire x1="0" y1="0" x2="5.08" y2="0" width="0.254" layer="94"/>

--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.5.0">
+<eagle version="9.6.2">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -11830,6 +11830,17 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <text x="-4.064" y="-0.635" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-5.461" y="-1.778" size="1.27" layer="25" ratio="10" rot="R90">&gt;NAME</text>
 </package>
+<package name="SOT323-5">
+<smd name="WDO" x="-2.1082" y="1.2954" dx="0.6096" dy="0.254" layer="1" rot="R180"/>
+<smd name="GND" x="-2.1082" y="0.635" dx="0.6096" dy="0.254" layer="1" rot="R180"/>
+<smd name="EN" x="-2.1082" y="0" dx="0.6096" dy="0.254" layer="1" rot="R180"/>
+<smd name="WDI" x="0" y="0" dx="0.6096" dy="0.254" layer="1" rot="R180"/>
+<smd name="VCC" x="0" y="1.2954" dx="0.6096" dy="0.254" layer="1"/>
+<wire x1="-1.8542" y1="1.651" x2="-1.8542" y2="-0.381" width="0.127" layer="21"/>
+<wire x1="-1.8542" y1="-0.381" x2="-0.254" y2="-0.381" width="0.127" layer="21"/>
+<wire x1="-0.254" y1="-0.381" x2="-0.254" y2="1.651" width="0.127" layer="21"/>
+<wire x1="-0.254" y1="1.651" x2="-1.8542" y2="1.651" width="0.127" layer="21"/>
+</package>
 </packages>
 <packages3d>
 <package3d name="2X03" urn="urn:adsk.eagle:package:22462/2" type="model">
@@ -21542,26 +21553,6 @@ Littelfuse 1812L Series Surface Mount PTC (resettable) Fuse
 </device>
 </devices>
 </deviceset>
-<deviceset name="STWD100">
-<description>STWD100 Watchdog timer</description>
-<gates>
-<gate name="G$1" symbol="STWD100" x="-7.62" y="7.62"/>
-</gates>
-<devices>
-<device name="" package="SOT23-5">
-<connects>
-<connect gate="G$1" pin="EN" pad="EN"/>
-<connect gate="G$1" pin="GND" pad="GND"/>
-<connect gate="G$1" pin="VCC" pad="VCC"/>
-<connect gate="G$1" pin="WDI" pad="WDI"/>
-<connect gate="G$1" pin="WDO" pad="WDO"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
 <deviceset name="JUMPER" prefix="J">
 <description>Jumper for changing operation of a device</description>
 <gates>
@@ -25596,6 +25587,9 @@ Dimensions: 5 mm x 20 mm
 <connect gate="G$1" pin="3" pad="P$3"/>
 <connect gate="G$1" pin="4" pad="P$4"/>
 </connects>
+<technologies>
+<technology name=""/>
+</technologies>
 </device>
 </devices>
 </deviceset>
@@ -25620,6 +25614,46 @@ Dimensions: 5 mm x 20 mm
 <connect gate="G$1" pin="VCCI2" pad="8"/>
 <connect gate="G$1" pin="VSSA" pad="14"/>
 <connect gate="G$1" pin="VSSB" pad="9"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="STWD100NYWY3F">
+<description>STWD100 Watchdog Timer (open-drain configuration)</description>
+<gates>
+<gate name="G$1" symbol="STWD100" x="-7.62" y="7.62"/>
+</gates>
+<devices>
+<device name="" package="SOT23-5">
+<connects>
+<connect gate="G$1" pin="EN" pad="EN"/>
+<connect gate="G$1" pin="GND" pad="GND"/>
+<connect gate="G$1" pin="VCC" pad="VCC"/>
+<connect gate="G$1" pin="WDI" pad="WDI"/>
+<connect gate="G$1" pin="WDO" pad="WDO"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="STWD100PYW83F">
+<description>STWD100 Watchdog Timer (push-pull configuration)</description>
+<gates>
+<gate name="G$1" symbol="STWD100" x="-7.62" y="7.62"/>
+</gates>
+<devices>
+<device name="" package="SOT323-5">
+<connects>
+<connect gate="G$1" pin="EN" pad="EN"/>
+<connect gate="G$1" pin="GND" pad="GND"/>
+<connect gate="G$1" pin="VCC" pad="VCC"/>
+<connect gate="G$1" pin="WDI" pad="WDI"/>
+<connect gate="G$1" pin="WDO" pad="WDO"/>
 </connects>
 <technologies>
 <technology name=""/>


### PR DESCRIPTION
# Pull Request (PR) into Circuits-Support-2020

## Part Description
Fixes the STWD100 part by splitting into two new devices representing the push-pull and open-drain version:
* STWD100PYW83F
* STWD100NYWY3F
Adds a new footprint for the push-pull version:
* SOT323-5

## Additional Information
* [STWD100 Datasheet](https://www.st.com/resource/en/datasheet/stwd100.pdf) 

## Checklist
- [x] Did you create any new schematics or boards?
- - [ ] Did you *make a PR* for them in `circuits-2020`? If so, please pause until you get this PR merged.
- [x] Did you pull `master` into your branch?
- - [x] Did you *check for merge conflicts*?
- - [x] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the below template?
- [x] Did you assign the right people for review (on the right)?