### PR TITLE
Updated 555 timer symbol

### DIFF
--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -12441,15 +12441,16 @@ DC/DC</text>
 <wire x1="27.94" y1="0" x2="27.94" y2="20.32" width="0.254" layer="94"/>
 <wire x1="27.94" y1="20.32" x2="0" y2="20.32" width="0.254" layer="94"/>
 <wire x1="0" y1="20.32" x2="0" y2="0" width="0.254" layer="94"/>
-<text x="15.24" y="10.16" size="1.778" layer="95" align="center">&gt;Name</text>
-<pin name="6" x="-5.08" y="2.54" length="middle"/>
-<pin name="2" x="7.62" y="-5.08" length="middle" rot="R90"/>
-<pin name="1" x="20.32" y="-5.08" length="middle" rot="R90"/>
-<pin name="5" x="33.02" y="2.54" length="middle" rot="R180"/>
-<pin name="3" x="33.02" y="17.78" length="middle" rot="R180"/>
-<pin name="8" x="20.32" y="25.4" length="middle" rot="R270"/>
-<pin name="4" x="7.62" y="25.4" length="middle" rot="R270"/>
-<pin name="7" x="-5.08" y="17.78" length="middle"/>
+<text x="0" y="20.32" size="1.778" layer="95">&gt;NAME</text>
+<pin name="THRESHOLD" x="-5.08" y="5.08" length="middle" direction="pas"/>
+<pin name="TRIGGER" x="-5.08" y="15.24" length="middle" direction="pas"/>
+<pin name="GND" x="33.02" y="2.54" length="middle" direction="pas" rot="R180"/>
+<pin name="CONTROL" x="-5.08" y="7.62" length="middle" direction="pas"/>
+<pin name="OUTPUT" x="33.02" y="17.78" length="middle" direction="pas" rot="R180"/>
+<pin name="VCC" x="-5.08" y="17.78" length="middle" direction="pas"/>
+<pin name="RESET" x="-5.08" y="12.7" length="middle" direction="pas"/>
+<pin name="DISCHARGE" x="-5.08" y="2.54" length="middle" direction="pas"/>
+<text x="0" y="0" size="1.778" layer="96" align="top-left">&gt;VALUE</text>
 </symbol>
 <symbol name="DIL2">
 <wire x1="-5.08" y1="1.27" x2="-5.08" y2="-1.524" width="0.254" layer="94"/>
@@ -17739,14 +17740,14 @@ LM555CN/NOPB</description>
 <devices>
 <device name="" package="DIL08">
 <connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-<connect gate="G$1" pin="3" pad="3"/>
-<connect gate="G$1" pin="4" pad="4"/>
-<connect gate="G$1" pin="5" pad="5"/>
-<connect gate="G$1" pin="6" pad="6"/>
-<connect gate="G$1" pin="7" pad="7"/>
-<connect gate="G$1" pin="8" pad="8"/>
+<connect gate="G$1" pin="CONTROL" pad="5"/>
+<connect gate="G$1" pin="DISCHARGE" pad="7"/>
+<connect gate="G$1" pin="GND" pad="1"/>
+<connect gate="G$1" pin="OUTPUT" pad="3"/>
+<connect gate="G$1" pin="RESET" pad="4"/>
+<connect gate="G$1" pin="THRESHOLD" pad="6"/>
+<connect gate="G$1" pin="TRIGGER" pad="2"/>
+<connect gate="G$1" pin="VCC" pad="8"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -24578,14 +24579,14 @@ Variant 2: Addressable/Multi-Drop Configuration
 <devices>
 <device name="SO-8" package="SOIC-08">
 <connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-<connect gate="G$1" pin="3" pad="3"/>
-<connect gate="G$1" pin="4" pad="4"/>
-<connect gate="G$1" pin="5" pad="5"/>
-<connect gate="G$1" pin="6" pad="6"/>
-<connect gate="G$1" pin="7" pad="7"/>
-<connect gate="G$1" pin="8" pad="8"/>
+<connect gate="G$1" pin="CONTROL" pad="5"/>
+<connect gate="G$1" pin="DISCHARGE" pad="7"/>
+<connect gate="G$1" pin="GND" pad="1"/>
+<connect gate="G$1" pin="OUTPUT" pad="3"/>
+<connect gate="G$1" pin="RESET" pad="4"/>
+<connect gate="G$1" pin="THRESHOLD" pad="6"/>
+<connect gate="G$1" pin="TRIGGER" pad="2"/>
+<connect gate="G$1" pin="VCC" pad="8"/>
 </connects>
 <technologies>
 <technology name=""/>


### PR DESCRIPTION
# Pull Request (PR) into Circuits-Support-2020

## Part Description
Changed the 555_TIMER symbol to match what was shown during training, which is easier to read and use. This symbol is used in the 555_TIMER and NA555 devices. 

## Checklist
- [ ] Did you create any new schematics or boards?
- - [ ] Did you *make a PR* for them in `circuits-2020`? If so, please pause until you get this PR merged.
- [x] Did you pull `master` into your branch?
- - [x] Did you *check for merge conflicts*?
- - [x] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the above template?
- [x] Did you assign the right people for review (on the right)?
