### PR TITLE
Mounting Holes + Pogo Pins

### DIFF
--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -11579,7 +11579,7 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <smd name="P$1" x="0" y="0" dx="11.303" dy="13.208" layer="1"/>
 </package>
 <package name="CONTACT_SPRING">
-<pad name="P$1" x="0" y="0" drill="0.635" diameter="1.8288" rot="R90"/>
+<pad name="P$1" x="0" y="0" drill="0.7366" diameter="1.8288" rot="R90"/>
 <circle x="0" y="0" radius="1.1938" width="0.127" layer="21"/>
 <circle x="0" y="0" radius="1.3208" width="0.127" layer="40"/>
 <circle x="0" y="0" radius="1.3208" width="0.127" layer="39"/>

--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="50" unitdist="mil" unit="mil" style="lines" multiple="1" display="no" altdistance="5" altunitdist="mil" altunit="mil"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -11579,10 +11579,10 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <smd name="P$1" x="0" y="0" dx="11.303" dy="13.208" layer="1"/>
 </package>
 <package name="CONTACT_SPRING">
-<pad name="P$1" x="0" y="0" drill="0.51" diameter="1.83" rot="R90"/>
-<circle x="0" y="0" radius="1.395" width="0.127" layer="21"/>
-<circle x="0" y="0" radius="1.5" width="0.127" layer="40"/>
-<circle x="0" y="0" radius="1.5" width="0.127" layer="39"/>
+<pad name="P$1" x="0" y="0" drill="0.635" diameter="1.8288" rot="R90"/>
+<circle x="0" y="0" radius="1.1938" width="0.127" layer="21"/>
+<circle x="0" y="0" radius="1.3208" width="0.127" layer="40"/>
+<circle x="0" y="0" radius="1.3208" width="0.127" layer="39"/>
 </package>
 <package name="QFP80P900X900X120-32N">
 <wire x1="3.4" y1="3.4" x2="3.4" y2="-3.4" width="0.1524" layer="21"/>
@@ -12005,6 +12005,20 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <wire x1="0.8128" y1="-1.0668" x2="0.8128" y2="-0.9398" width="0.1524" layer="51" curve="-180"/>
 <wire x1="0.8128" y1="-1.5748" x2="0.8128" y2="-1.4224" width="0.1524" layer="51" curve="-180"/>
 <text x="-3.2766" y="3.175" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+</package>
+<package name="M3_MOUNTING">
+<hole x="0" y="0" drill="3.4"/>
+<circle x="0" y="0" radius="3" width="0.127" layer="39"/>
+<circle x="0" y="0" radius="3" width="0.127" layer="40"/>
+<circle x="0" y="0" radius="3" width="0.127" layer="41"/>
+<circle x="0" y="0" radius="3" width="0.127" layer="42"/>
+</package>
+<package name="M4_MOUNTING">
+<hole x="0" y="0" drill="4.5"/>
+<circle x="0" y="0" radius="3.75" width="0.127" layer="39"/>
+<circle x="0" y="0" radius="3.75" width="0.127" layer="40"/>
+<circle x="0" y="0" radius="3.75" width="0.127" layer="41"/>
+<circle x="0" y="0" radius="3.75" width="0.127" layer="42"/>
 </package>
 </packages>
 <packages3d>
@@ -25480,7 +25494,11 @@ Dimensions: 5 mm x 20 mm
 <deviceset name="BATTERY_SPRING">
 <description>&lt;b&gt; Keystone Electronics Battery Spring Contact &lt;/b&gt;
 &lt;br&gt;
-&lt;a href="http://keyelco.com/userAssets/file/M65p17.pdf"&gt;Datasheet&lt;/a&gt;</description>
+&lt;a href="http://keyelco.com/userAssets/file/M65p17.pdf"&gt;Datasheet&lt;/a&gt;
+&lt;br&gt; 
+&lt;b&gt; Mill-Max Pogo Pins &lt;/b&gt;
+&lt;br&gt;
+&lt;a href="https://www.mill-max.com/catalog/download/2019-08%3A019.6M.pdf"&gt;Datasheet&lt;/a&gt;</description>
 <gates>
 <gate name="G$1" symbol="MV" x="0" y="0" addlevel="always"/>
 </gates>


### PR DESCRIPTION
# Pull Request (PR) into Circuits-Support-2020

## Part Description

- This adds footprint for M3 and M4 mounting using standard hole size (3.4 and 4.5 mm respectively) and clearances on both top and bottom in tRestrict/bRestrict/tKeepout/bKeepout that can be used in the board view.
- Updates the Mill-Max Pogo Pin contact part (807-22-001-10-023101) 

## Additional Information
Pogo-Pin [Datasheet](https://www.mill-max.com/catalog/download/2019-08%3A019.6.pdf)
Pogo-Pin [Application Note](https://www.mill-max.com/engineering-notebooks/general-application-notes) for footprint

## Checklist
- [X] Did you create any new schematics or boards?
- - [ ] Did you *make a PR* for them in `circuits-2020`? If so, please pause until you get this PR merged.
- [x] Did you pull `master` into your branch?
- - [x] Did you *check for merge conflicts*?
- - [x] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the above template?
- [x] Did you assign the right people for review (on the right)?
