### PR TITLE
Added 0603 zener for 15V voltage regulation

### DIFF
--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -12053,6 +12053,10 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <wire x1="1.473" y1="-0.983" x2="-1.473" y2="-0.983" width="0.0508" layer="39"/>
 <wire x1="-1.473" y1="-0.983" x2="-1.473" y2="0.983" width="0.0508" layer="39"/>
 </package>
+<package name="U-DFN1608-2">
+<smd name="P$1" x="0" y="0" dx="1.01091875" dy="0.8001" layer="1" rot="R90"/>
+<smd name="P$2" x="0" y="-1.0922" dx="0.6096" dy="0.8001" layer="1" rot="R90"/>
+</package>
 </packages>
 <packages3d>
 <package3d name="2X03" urn="urn:adsk.eagle:package:22462/2" type="model">
@@ -16936,6 +16940,22 @@ Demo Board</text>
 <text x="-2.032" y="-4.318" size="1.524" layer="95">GND</text>
 <text x="-4.445" y="-0.635" size="1.524" layer="95">IN</text>
 <text x="0.635" y="-0.635" size="1.524" layer="95">OUT</text>
+</symbol>
+<symbol name="TVS_DIODE">
+<wire x1="0" y1="1.016" x2="0" y2="-1.27" width="0.254" layer="94"/>
+<pin name="A" x="-5.08" y="0" visible="off" length="short" direction="pas"/>
+<pin name="C" x="2.54" y="0" visible="off" length="short" direction="pas" rot="R180"/>
+<text x="-3.81" y="1.7526" size="1.778" layer="95">&gt;NAME</text>
+<text x="-3.81" y="-3.5814" size="1.778" layer="96">&gt;VALUE</text>
+<text x="-2.54" y="0" size="0.4064" layer="99" align="center">SpiceOrder 1</text>
+<text x="2.54" y="0" size="0.4064" layer="99" align="center">SpiceOrder 2</text>
+<polygon width="0.254" layer="94">
+<vertex x="-2.54" y="1.27"/>
+<vertex x="-2.54" y="-1.27"/>
+<vertex x="0" y="0"/>
+</polygon>
+<wire x1="0" y1="1.016" x2="0.508" y2="1.016" width="0.254" layer="94"/>
+<wire x1="0" y1="-1.27" x2="-0.508" y2="-1.27" width="0.254" layer="94"/>
 </symbol>
 </symbols>
 <devicesets>
@@ -26183,6 +26203,22 @@ Dimensions: 5 mm x 20 mm
 <connects>
 <connect gate="G$1" pin="A" pad="A"/>
 <connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="TVS_DIODE">
+<gates>
+<gate name="G$1" symbol="TVS_DIODE" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="U-DFN1608-2">
+<connects>
+<connect gate="G$1" pin="A" pad="P$1"/>
+<connect gate="G$1" pin="C" pad="P$2"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -12,16 +12,16 @@
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
 <layer number="3" name="Route3" color="4" fill="3" visible="no" active="no"/>
-<layer number="4" name="Route4" color="1" fill="4" visible="no" active="yes"/>
-<layer number="5" name="Route5" color="4" fill="4" visible="no" active="yes"/>
-<layer number="6" name="Route6" color="1" fill="8" visible="no" active="yes"/>
-<layer number="7" name="Route7" color="4" fill="8" visible="no" active="yes"/>
-<layer number="8" name="Route8" color="1" fill="2" visible="no" active="yes"/>
-<layer number="9" name="Route9" color="4" fill="2" visible="no" active="yes"/>
-<layer number="10" name="Route10" color="1" fill="7" visible="no" active="yes"/>
-<layer number="11" name="Route11" color="4" fill="7" visible="no" active="yes"/>
-<layer number="12" name="Route12" color="1" fill="5" visible="no" active="yes"/>
-<layer number="13" name="Route13" color="4" fill="5" visible="no" active="yes"/>
+<layer number="4" name="Route4" color="1" fill="4" visible="yes" active="yes"/>
+<layer number="5" name="Route5" color="4" fill="4" visible="yes" active="yes"/>
+<layer number="6" name="Route6" color="1" fill="8" visible="yes" active="yes"/>
+<layer number="7" name="Route7" color="4" fill="8" visible="yes" active="yes"/>
+<layer number="8" name="Route8" color="1" fill="2" visible="yes" active="yes"/>
+<layer number="9" name="Route9" color="4" fill="2" visible="yes" active="yes"/>
+<layer number="10" name="Route10" color="1" fill="7" visible="yes" active="yes"/>
+<layer number="11" name="Route11" color="4" fill="7" visible="yes" active="yes"/>
+<layer number="12" name="Route12" color="1" fill="5" visible="yes" active="yes"/>
+<layer number="13" name="Route13" color="4" fill="5" visible="yes" active="yes"/>
 <layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
 <layer number="15" name="Route15" color="4" fill="6" visible="no" active="no"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -80,86 +80,86 @@
 <layer number="98" name="Guide" color="6" fill="1" visible="no" active="yes"/>
 <layer number="99" name="SpiceOrder" color="7" fill="1" visible="no" active="no"/>
 <layer number="100" name="Muster" color="7" fill="1" visible="no" active="no"/>
-<layer number="101" name="Patch_Top" color="12" fill="4" visible="no" active="yes"/>
-<layer number="102" name="Vscore" color="7" fill="1" visible="no" active="yes"/>
-<layer number="103" name="tMap" color="7" fill="1" visible="no" active="yes"/>
+<layer number="101" name="Patch_Top" color="12" fill="4" visible="yes" active="yes"/>
+<layer number="102" name="Vscore" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="103" name="tMap" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="104" name="Name" color="16" fill="1" visible="yes" active="yes"/>
-<layer number="105" name="tPlate" color="7" fill="1" visible="no" active="yes"/>
-<layer number="106" name="bPlate" color="7" fill="1" visible="no" active="yes"/>
-<layer number="107" name="Crop" color="7" fill="1" visible="no" active="yes"/>
-<layer number="108" name="tplace-old" color="10" fill="1" visible="no" active="yes"/>
-<layer number="109" name="ref-old" color="11" fill="1" visible="no" active="yes"/>
-<layer number="110" name="fp0" color="7" fill="1" visible="no" active="yes"/>
-<layer number="111" name="LPC17xx" color="7" fill="1" visible="no" active="yes"/>
-<layer number="112" name="tSilk" color="7" fill="1" visible="no" active="yes"/>
-<layer number="113" name="IDFDebug" color="7" fill="1" visible="no" active="yes"/>
-<layer number="114" name="Badge_Outline" color="7" fill="1" visible="no" active="yes"/>
-<layer number="115" name="ReferenceISLANDS" color="7" fill="1" visible="no" active="yes"/>
-<layer number="116" name="Patch_BOT" color="9" fill="4" visible="no" active="yes"/>
-<layer number="117" name="mPads" color="7" fill="1" visible="no" active="yes"/>
-<layer number="118" name="Rect_Pads" color="7" fill="1" visible="no" active="yes"/>
-<layer number="119" name="mUnrouted" color="7" fill="1" visible="no" active="yes"/>
-<layer number="120" name="mDimension" color="7" fill="1" visible="no" active="yes"/>
-<layer number="121" name="_tsilk" color="7" fill="1" visible="no" active="yes"/>
-<layer number="122" name="_bsilk" color="7" fill="1" visible="no" active="yes"/>
-<layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
-<layer number="124" name="bTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="105" name="tPlate" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="106" name="bPlate" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="107" name="Crop" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="108" name="tplace-old" color="10" fill="1" visible="yes" active="yes"/>
+<layer number="109" name="ref-old" color="11" fill="1" visible="yes" active="yes"/>
+<layer number="110" name="fp0" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="111" name="LPC17xx" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="112" name="tSilk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="113" name="IDFDebug" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="114" name="Badge_Outline" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="115" name="ReferenceISLANDS" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="116" name="Patch_BOT" color="9" fill="4" visible="yes" active="yes"/>
+<layer number="117" name="mPads" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="118" name="Rect_Pads" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="119" name="mUnrouted" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="120" name="mDimension" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="121" name="_tsilk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="122" name="_bsilk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="125" name="_tNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="126" name="_bNames" color="7" fill="1" visible="no" active="yes"/>
-<layer number="127" name="_tValues" color="7" fill="1" visible="no" active="yes"/>
-<layer number="128" name="_bValues" color="7" fill="1" visible="no" active="yes"/>
-<layer number="129" name="Mask" color="7" fill="1" visible="no" active="yes"/>
-<layer number="130" name="mbStop" color="7" fill="1" visible="no" active="yes"/>
-<layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
-<layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
-<layer number="133" name="mtFinish" color="7" fill="1" visible="no" active="yes"/>
-<layer number="134" name="mbFinish" color="7" fill="1" visible="no" active="yes"/>
-<layer number="135" name="mtGlue" color="7" fill="1" visible="no" active="yes"/>
-<layer number="136" name="mbGlue" color="7" fill="1" visible="no" active="yes"/>
-<layer number="137" name="mtTest" color="7" fill="1" visible="no" active="yes"/>
-<layer number="138" name="mbTest" color="7" fill="1" visible="no" active="yes"/>
-<layer number="139" name="mtKeepout" color="7" fill="1" visible="no" active="yes"/>
-<layer number="140" name="mbKeepout" color="7" fill="1" visible="no" active="yes"/>
-<layer number="141" name="mtRestrict" color="7" fill="1" visible="no" active="yes"/>
-<layer number="142" name="mbRestrict" color="7" fill="1" visible="no" active="yes"/>
-<layer number="143" name="mvRestrict" color="7" fill="1" visible="no" active="yes"/>
-<layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
-<layer number="145" name="mHoles" color="7" fill="1" visible="no" active="yes"/>
-<layer number="146" name="mMilling" color="7" fill="1" visible="no" active="yes"/>
-<layer number="147" name="mMeasures" color="7" fill="1" visible="no" active="yes"/>
-<layer number="148" name="mDocument" color="7" fill="1" visible="no" active="yes"/>
-<layer number="149" name="mReference" color="7" fill="1" visible="no" active="yes"/>
-<layer number="150" name="Notes" color="7" fill="1" visible="no" active="yes"/>
-<layer number="151" name="HeatSink" color="7" fill="1" visible="no" active="yes"/>
-<layer number="152" name="_bDocu" color="7" fill="1" visible="no" active="yes"/>
-<layer number="153" name="FabDoc1" color="7" fill="1" visible="no" active="yes"/>
-<layer number="154" name="FabDoc2" color="7" fill="1" visible="no" active="yes"/>
-<layer number="155" name="FabDoc3" color="7" fill="1" visible="no" active="yes"/>
-<layer number="156" name="HVSpacing" color="12" fill="1" visible="no" active="yes"/>
-<layer number="191" name="mNets" color="7" fill="1" visible="no" active="yes"/>
-<layer number="192" name="mBusses" color="7" fill="1" visible="no" active="yes"/>
-<layer number="193" name="mPins" color="7" fill="1" visible="no" active="yes"/>
-<layer number="194" name="mSymbols" color="7" fill="1" visible="no" active="yes"/>
-<layer number="195" name="mNames" color="7" fill="1" visible="no" active="yes"/>
-<layer number="196" name="mValues" color="7" fill="1" visible="no" active="yes"/>
-<layer number="199" name="Contour" color="7" fill="1" visible="no" active="yes"/>
-<layer number="200" name="200bmp" color="1" fill="10" visible="no" active="yes"/>
-<layer number="201" name="201bmp" color="2" fill="10" visible="no" active="yes"/>
-<layer number="202" name="202bmp" color="3" fill="10" visible="no" active="yes"/>
-<layer number="203" name="203bmp" color="4" fill="10" visible="no" active="yes"/>
-<layer number="204" name="204bmp" color="5" fill="10" visible="no" active="yes"/>
-<layer number="205" name="205bmp" color="6" fill="10" visible="no" active="yes"/>
-<layer number="206" name="206bmp" color="7" fill="10" visible="no" active="yes"/>
-<layer number="207" name="207bmp" color="8" fill="10" visible="no" active="yes"/>
-<layer number="208" name="208bmp" color="9" fill="10" visible="no" active="yes"/>
-<layer number="209" name="209bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="210" name="210bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="211" name="211bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="212" name="212bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="213" name="213bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="214" name="214bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="215" name="215bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="216" name="216bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="126" name="_bNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="127" name="_tValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="128" name="_bValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="129" name="Mask" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="130" name="mbStop" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="133" name="mtFinish" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="134" name="mbFinish" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="135" name="mtGlue" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="136" name="mbGlue" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="137" name="mtTest" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="138" name="mbTest" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="139" name="mtKeepout" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="140" name="mbKeepout" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="141" name="mtRestrict" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="142" name="mbRestrict" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="143" name="mvRestrict" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="145" name="mHoles" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="146" name="mMilling" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="147" name="mMeasures" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="148" name="mDocument" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="149" name="mReference" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="150" name="Notes" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="151" name="HeatSink" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="152" name="_bDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="153" name="FabDoc1" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="154" name="FabDoc2" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="155" name="FabDoc3" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="156" name="HVSpacing" color="12" fill="1" visible="yes" active="yes"/>
+<layer number="191" name="mNets" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="192" name="mBusses" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="193" name="mPins" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="194" name="mSymbols" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="195" name="mNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="196" name="mValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="200" name="200bmp" color="1" fill="10" visible="yes" active="yes"/>
+<layer number="201" name="201bmp" color="2" fill="10" visible="yes" active="yes"/>
+<layer number="202" name="202bmp" color="3" fill="10" visible="yes" active="yes"/>
+<layer number="203" name="203bmp" color="4" fill="10" visible="yes" active="yes"/>
+<layer number="204" name="204bmp" color="5" fill="10" visible="yes" active="yes"/>
+<layer number="205" name="205bmp" color="6" fill="10" visible="yes" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="10" visible="yes" active="yes"/>
+<layer number="207" name="207bmp" color="8" fill="10" visible="yes" active="yes"/>
+<layer number="208" name="208bmp" color="9" fill="10" visible="yes" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="217" name="217bmp" color="18" fill="1" visible="no" active="no"/>
 <layer number="218" name="218bmp" color="19" fill="1" visible="no" active="no"/>
 <layer number="219" name="219bmp" color="20" fill="1" visible="no" active="no"/>
@@ -168,23 +168,23 @@
 <layer number="222" name="222bmp" color="23" fill="1" visible="no" active="no"/>
 <layer number="223" name="223bmp" color="24" fill="1" visible="no" active="no"/>
 <layer number="224" name="224bmp" color="25" fill="1" visible="no" active="no"/>
-<layer number="225" name="225bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="226" name="226bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="227" name="227bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="228" name="228bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="229" name="229bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="230" name="230bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="231" name="231bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="no" active="yes"/>
-<layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="no" active="yes"/>
-<layer number="248" name="Housing" color="7" fill="1" visible="no" active="yes"/>
-<layer number="249" name="Edge" color="7" fill="1" visible="no" active="yes"/>
+<layer number="225" name="225bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="226" name="226bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="227" name="227bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="228" name="228bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="229" name="229bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="230" name="230bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="231" name="231bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="248" name="Housing" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="249" name="Edge" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
 <layer number="251" name="SMDround" color="12" fill="11" visible="no" active="no"/>
 <layer number="252" name="BR-BS" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="253" name="BR-LS" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="254" name="cooling" color="7" fill="1" visible="no" active="yes"/>
-<layer number="255" name="routoute" color="7" fill="1" visible="no" active="yes"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="255" name="routoute" color="7" fill="1" visible="yes" active="yes"/>
 </layers>
 <library>
 <packages>
@@ -12057,6 +12057,159 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <smd name="P$1" x="0" y="0" dx="1.01091875" dy="0.8001" layer="1" rot="R90"/>
 <smd name="P$2" x="0" y="-1.0922" dx="0.6096" dy="0.8001" layer="1" rot="R90"/>
 </package>
+<package name="QFN_BNO055">
+<smd name="6" x="-2.249996875" y="-1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="2" x="-2.2352" y="0.75" dx="0.3048" dy="0.4318" layer="1" rot="R270"/>
+<smd name="3" x="-2.2352" y="0.25" dx="0.3048" dy="0.4318" layer="1" rot="R270"/>
+<smd name="4" x="-2.2352" y="-0.25" dx="0.3048" dy="0.4318" layer="1" rot="R270"/>
+<smd name="5" x="-2.2352" y="-0.75" dx="0.3048" dy="0.4318" layer="1" rot="R270"/>
+<smd name="7" x="-1.75" y="-1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="8" x="-1.25" y="-1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="9" x="-0.75" y="-1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="10" x="-0.25" y="-1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="11" x="0.25" y="-1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="12" x="0.75" y="-1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="13" x="1.25" y="-1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="14" x="1.75" y="-1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="15" x="2.249996875" y="-1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="16" x="2.2352" y="-0.75" dx="0.3048" dy="0.4318" layer="1" rot="R270"/>
+<smd name="17" x="2.2352" y="-0.25" dx="0.3048" dy="0.4318" layer="1" rot="R270"/>
+<smd name="18" x="2.2352" y="0.25" dx="0.3048" dy="0.4318" layer="1" rot="R270"/>
+<smd name="19" x="2.2352" y="0.75" dx="0.3048" dy="0.4318" layer="1" rot="R270"/>
+<smd name="20" x="2.249996875" y="1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="21" x="1.75" y="1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="22" x="1.25" y="1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="23" x="0.75" y="1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="24" x="0.25" y="1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="25" x="-0.25" y="1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="26" x="-0.75" y="1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="27" x="-1.25" y="1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="28" x="-1.75" y="1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<smd name="1" x="-2.249996875" y="1.5367" dx="0.3048" dy="0.5334" layer="1" rot="R180"/>
+<wire x1="-2.5908" y1="0.635" x2="-1.3208" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="1.6002" y1="1.905" x2="1.905" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="1.905" y1="1.905" x2="1.905" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="1.905" y1="1.8034" x2="1.6002" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="1.6002" y1="1.8034" x2="1.6002" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="1.0922" y1="1.905" x2="1.397" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="1.397" y1="1.905" x2="1.397" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="1.397" y1="1.8034" x2="1.0922" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="1.0922" y1="1.8034" x2="1.0922" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="0.6096" y1="1.905" x2="0.9144" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="0.9144" y1="1.905" x2="0.9144" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="0.9144" y1="1.8034" x2="0.6096" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="0.6096" y1="1.8034" x2="0.6096" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="0.1016" y1="1.905" x2="0.4064" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="0.4064" y1="1.905" x2="0.4064" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="0.4064" y1="1.8034" x2="0.1016" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="0.1016" y1="1.8034" x2="0.1016" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-0.4064" y1="1.905" x2="-0.1016" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-0.1016" y1="1.905" x2="-0.1016" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="-0.1016" y1="1.8034" x2="-0.4064" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="-0.4064" y1="1.8034" x2="-0.4064" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-0.9144" y1="1.905" x2="-0.6096" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-0.6096" y1="1.905" x2="-0.6096" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="-0.6096" y1="1.8034" x2="-0.9144" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="-0.9144" y1="1.8034" x2="-0.9144" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-1.397" y1="1.905" x2="-1.0922" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-1.0922" y1="1.905" x2="-1.0922" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="-1.0922" y1="1.8034" x2="-1.397" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="-1.397" y1="1.8034" x2="-1.397" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-1.905" y1="1.905" x2="-1.6002" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-1.6002" y1="1.905" x2="-1.6002" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="-1.6002" y1="1.8034" x2="-1.905" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="-1.905" y1="1.8034" x2="-1.905" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-2.5908" y1="0.6096" x2="-2.5908" y2="0.9144" width="0.1524" layer="51"/>
+<wire x1="-2.5908" y1="0.9144" x2="-2.4384" y2="0.9144" width="0.1524" layer="51"/>
+<wire x1="-2.4384" y1="0.9144" x2="-2.4384" y2="0.6096" width="0.1524" layer="51"/>
+<wire x1="-2.4384" y1="0.6096" x2="-2.5908" y2="0.6096" width="0.1524" layer="51"/>
+<wire x1="-2.5908" y1="0.1016" x2="-2.5908" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="-2.5908" y1="0.4064" x2="-2.4384" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="-2.4384" y1="0.4064" x2="-2.4384" y2="0.1016" width="0.1524" layer="51"/>
+<wire x1="-2.4384" y1="0.1016" x2="-2.5908" y2="0.1016" width="0.1524" layer="51"/>
+<wire x1="-2.5908" y1="-0.4064" x2="-2.5908" y2="-0.1016" width="0.1524" layer="51"/>
+<wire x1="-2.5908" y1="-0.1016" x2="-2.4384" y2="-0.1016" width="0.1524" layer="51"/>
+<wire x1="-2.4384" y1="-0.1016" x2="-2.4384" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="-2.4384" y1="-0.4064" x2="-2.5908" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="-2.5908" y1="-0.9144" x2="-2.5908" y2="-0.6096" width="0.1524" layer="51"/>
+<wire x1="-2.5908" y1="-0.6096" x2="-2.4384" y2="-0.6096" width="0.1524" layer="51"/>
+<wire x1="-2.4384" y1="-0.6096" x2="-2.4384" y2="-0.9144" width="0.1524" layer="51"/>
+<wire x1="-2.4384" y1="-0.9144" x2="-2.5908" y2="-0.9144" width="0.1524" layer="51"/>
+<wire x1="-1.6002" y1="-1.905" x2="-1.905" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="-1.905" y1="-1.905" x2="-1.905" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="-1.905" y1="-1.8034" x2="-1.6002" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="-1.6002" y1="-1.8034" x2="-1.6002" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="-1.0922" y1="-1.905" x2="-1.397" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="-1.397" y1="-1.905" x2="-1.397" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="-1.397" y1="-1.8034" x2="-1.0922" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="-1.0922" y1="-1.8034" x2="-1.0922" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="-0.6096" y1="-1.905" x2="-0.9144" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="-0.9144" y1="-1.905" x2="-0.9144" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="-0.9144" y1="-1.8034" x2="-0.6096" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="-0.6096" y1="-1.8034" x2="-0.6096" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="-0.1016" y1="-1.905" x2="-0.4064" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="-0.4064" y1="-1.905" x2="-0.4064" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="-0.4064" y1="-1.8034" x2="-0.1016" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="-0.1016" y1="-1.8034" x2="-0.1016" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="0.4064" y1="-1.905" x2="0.1016" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="0.1016" y1="-1.905" x2="0.1016" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="0.1016" y1="-1.8034" x2="0.4064" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="0.4064" y1="-1.8034" x2="0.4064" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="0.9144" y1="-1.905" x2="0.6096" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="0.6096" y1="-1.905" x2="0.6096" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="0.6096" y1="-1.8034" x2="0.9144" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="0.9144" y1="-1.8034" x2="0.9144" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="1.397" y1="-1.905" x2="1.0922" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="1.0922" y1="-1.905" x2="1.0922" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="1.0922" y1="-1.8034" x2="1.397" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="1.397" y1="-1.8034" x2="1.397" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="1.905" y1="-1.905" x2="1.6002" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="1.6002" y1="-1.905" x2="1.6002" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="1.6002" y1="-1.8034" x2="1.905" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="1.905" y1="-1.8034" x2="1.905" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="2.5908" y1="-0.6096" x2="2.5908" y2="-0.9144" width="0.1524" layer="51"/>
+<wire x1="2.5908" y1="-0.9144" x2="2.4384" y2="-0.9144" width="0.1524" layer="51"/>
+<wire x1="2.4384" y1="-0.9144" x2="2.4384" y2="-0.6096" width="0.1524" layer="51"/>
+<wire x1="2.4384" y1="-0.6096" x2="2.5908" y2="-0.6096" width="0.1524" layer="51"/>
+<wire x1="2.5908" y1="-0.1016" x2="2.5908" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="2.5908" y1="-0.4064" x2="2.4384" y2="-0.4064" width="0.1524" layer="51"/>
+<wire x1="2.4384" y1="-0.4064" x2="2.4384" y2="-0.1016" width="0.1524" layer="51"/>
+<wire x1="2.4384" y1="-0.1016" x2="2.5908" y2="-0.1016" width="0.1524" layer="51"/>
+<wire x1="2.5908" y1="0.4064" x2="2.5908" y2="0.1016" width="0.1524" layer="51"/>
+<wire x1="2.5908" y1="0.1016" x2="2.4384" y2="0.1016" width="0.1524" layer="51"/>
+<wire x1="2.4384" y1="0.1016" x2="2.4384" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="2.4384" y1="0.4064" x2="2.5908" y2="0.4064" width="0.1524" layer="51"/>
+<wire x1="2.5908" y1="0.9144" x2="2.5908" y2="0.6096" width="0.1524" layer="51"/>
+<wire x1="2.5908" y1="0.6096" x2="2.4384" y2="0.6096" width="0.1524" layer="51"/>
+<wire x1="2.4384" y1="0.6096" x2="2.4384" y2="0.9144" width="0.1524" layer="51"/>
+<wire x1="2.4384" y1="0.9144" x2="2.5908" y2="0.9144" width="0.1524" layer="51"/>
+<wire x1="-2.5908" y1="-1.905" x2="-2.413" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="-2.413" y1="-1.905" x2="-2.1082" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="-2.1082" y1="-1.905" x2="2.1082" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="2.5908" y1="-1.905" x2="2.5908" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="2.5908" y1="1.905" x2="2.413" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="2.413" y1="1.905" x2="2.1082" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="2.1082" y1="1.905" x2="-2.1082" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-2.5908" y1="1.905" x2="-2.5908" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="-2.5908" y1="1.905" x2="-2.413" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-2.413" y1="1.905" x2="-2.1082" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-2.1082" y1="1.905" x2="-2.1082" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="-2.1082" y1="1.8034" x2="-2.413" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="-2.413" y1="1.8034" x2="-2.413" y2="1.905" width="0.1524" layer="51"/>
+<wire x1="-2.413" y1="-1.905" x2="-2.413" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="-2.413" y1="-1.8034" x2="-2.1082" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="-2.1082" y1="-1.8034" x2="-2.1082" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="2.5908" y1="-1.905" x2="2.413" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="2.413" y1="-1.905" x2="2.1082" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="2.1082" y1="-1.905" x2="2.1082" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="2.1082" y1="-1.8034" x2="2.413" y2="-1.8034" width="0.1524" layer="51"/>
+<wire x1="2.413" y1="-1.8034" x2="2.413" y2="-1.905" width="0.1524" layer="51"/>
+<wire x1="2.413" y1="1.905" x2="2.413" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="2.413" y1="1.8034" x2="2.1082" y2="1.8034" width="0.1524" layer="51"/>
+<wire x1="2.1082" y1="1.8034" x2="2.1082" y2="1.905" width="0.1524" layer="51"/>
+<text x="-2.54" y="2.159" size="0.4572" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+<text x="-0.635" y="-2.54" size="0.4572" layer="27" align="bottom-right">&gt;Value</text>
+</package>
 </packages>
 <packages3d>
 <package3d name="2X03" urn="urn:adsk.eagle:package:22462/2" type="model">
@@ -16956,6 +17109,34 @@ Demo Board</text>
 </polygon>
 <wire x1="0" y1="1.016" x2="0.508" y2="1.016" width="0.254" layer="94"/>
 <wire x1="0" y1="-1.27" x2="-0.508" y2="-1.27" width="0.254" layer="94"/>
+</symbol>
+<symbol name="BNO055">
+<description>The bno055 schematic for the surface mount chip</description>
+<pin name="GND" x="2.54" y="-2.54" length="middle" direction="pas"/>
+<pin name="VDD" x="2.54" y="-5.08" length="middle" direction="pwr"/>
+<pin name="NBOOT_LOAD_PIN" x="2.54" y="-7.62" length="middle" direction="in"/>
+<pin name="PS1" x="2.54" y="-10.16" length="middle" direction="in"/>
+<pin name="PS0" x="2.54" y="-12.7" length="middle" direction="in"/>
+<pin name="SWDIO" x="2.54" y="-15.24" length="middle"/>
+<pin name="SWCLK" x="2.54" y="-17.78" length="middle" direction="in"/>
+<pin name="CAP" x="2.54" y="-20.32" length="middle" direction="pas"/>
+<pin name="BL_IND" x="2.54" y="-22.86" length="middle" direction="out"/>
+<pin name="NRESET" x="2.54" y="-25.4" length="middle" direction="pas"/>
+<pin name="INT" x="2.54" y="-33.02" length="middle" direction="out"/>
+<pin name="COM3" x="63.5" y="-27.94" length="middle" direction="in" rot="R180"/>
+<pin name="COM2" x="63.5" y="-25.4" length="middle" rot="R180"/>
+<pin name="COM1" x="63.5" y="-22.86" length="middle" rot="R180"/>
+<pin name="COM0" x="63.5" y="-20.32" length="middle" rot="R180"/>
+<pin name="GNDIO" x="63.5" y="-7.62" length="middle" direction="pas" rot="R180"/>
+<pin name="XOUT32" x="63.5" y="-5.08" length="middle" direction="out" rot="R180"/>
+<pin name="XIN32" x="63.5" y="-2.54" length="middle" direction="in" rot="R180"/>
+<pin name="VDDIO" x="63.5" y="0" length="middle" direction="pwr" rot="R180"/>
+<wire x1="7.62" y1="5.08" x2="7.62" y2="-38.1" width="0.1524" layer="94"/>
+<wire x1="7.62" y1="-38.1" x2="58.42" y2="-38.1" width="0.1524" layer="94"/>
+<wire x1="58.42" y1="-38.1" x2="58.42" y2="5.08" width="0.1524" layer="94"/>
+<wire x1="58.42" y1="5.08" x2="7.62" y2="5.08" width="0.1524" layer="94"/>
+<text x="7.62" y="6.35" size="2.0828" layer="95" ratio="6" rot="SR0">&gt;Name</text>
+<text x="7.62" y="-41.91" size="2.1844" layer="96">&gt;Value</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -26219,6 +26400,48 @@ Dimensions: 5 mm x 20 mm
 <connects>
 <connect gate="G$1" pin="A" pad="P$1"/>
 <connect gate="G$1" pin="C" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="BNO055" prefix="U">
+<description>9-DOF IMU
+&lt;ul&gt;
+&lt;li&gt;Quaternion&lt;/li&gt;
+&lt;li&gt;Gravity&lt;/li&gt;
+&lt;li&gt;Linear Acceleration&lt;/li&gt;
+&lt;li&gt;Robust Heading&lt;/li&gt;
+&lt;li&gt;Rotation&lt;/li&gt;
+&lt;/ul&gt;
+&lt;a href="https://cdn-shop.adafruit.com/datasheets/BST_BNO055_DS000_12.pdf"&gt;See datasheet&lt;/a&gt;</description>
+<gates>
+<gate name="A" symbol="BNO055" x="0" y="0"/>
+</gates>
+<devices>
+<device name="-SURFACE-MOUNT" package="QFN_BNO055">
+<connects>
+<connect gate="A" pin="BL_IND" pad="10"/>
+<connect gate="A" pin="CAP" pad="9"/>
+<connect gate="A" pin="COM0" pad="20"/>
+<connect gate="A" pin="COM1" pad="19"/>
+<connect gate="A" pin="COM2" pad="18"/>
+<connect gate="A" pin="COM3" pad="17"/>
+<connect gate="A" pin="GND" pad="2"/>
+<connect gate="A" pin="GNDIO" pad="25"/>
+<connect gate="A" pin="INT" pad="14"/>
+<connect gate="A" pin="NBOOT_LOAD_PIN" pad="4"/>
+<connect gate="A" pin="NRESET" pad="11"/>
+<connect gate="A" pin="PS0" pad="6"/>
+<connect gate="A" pin="PS1" pad="5"/>
+<connect gate="A" pin="SWCLK" pad="8"/>
+<connect gate="A" pin="SWDIO" pad="7"/>
+<connect gate="A" pin="VDD" pad="3"/>
+<connect gate="A" pin="VDDIO" pad="28"/>
+<connect gate="A" pin="XIN32" pad="27"/>
+<connect gate="A" pin="XOUT32" pad="26"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -12037,6 +12037,22 @@ Same pad spacing as SOIC-16, but larger footprint</description>
 <wire x1="0" y1="0.381" x2="0" y2="0.127" width="0.1524" layer="21"/>
 <wire x1="0" y1="-0.381" x2="0" y2="-0.127" width="0.1524" layer="21"/>
 </package>
+<package name="0603_D">
+<wire x1="-0.1" y1="0.5" x2="0.1" y2="0.5" width="0.1524" layer="21"/>
+<wire x1="-0.1" y1="-0.5" x2="0.1" y2="-0.5" width="0.1524" layer="21"/>
+<smd name="A" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
+<smd name="C" x="0.85" y="0" dx="1.1" dy="1" layer="1" roundness="30"/>
+<text x="0" y="0.635" size="0.4064" layer="25" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-0.635" size="0.4064" layer="27" align="top-center">&gt;VALUE</text>
+<wire x1="-0.1524" y1="0" x2="0.1524" y2="0" width="0.127" layer="21"/>
+<wire x1="0.1524" y1="0" x2="0" y2="-0.2032" width="0.127" layer="21"/>
+<wire x1="0" y1="-0.2032" x2="0" y2="0.2032" width="0.127" layer="21"/>
+<wire x1="0" y1="0.2032" x2="0.1524" y2="0" width="0.127" layer="21"/>
+<wire x1="-1.473" y1="0.983" x2="1.473" y2="0.983" width="0.0508" layer="39"/>
+<wire x1="1.473" y1="0.983" x2="1.473" y2="-0.983" width="0.0508" layer="39"/>
+<wire x1="1.473" y1="-0.983" x2="-1.473" y2="-0.983" width="0.0508" layer="39"/>
+<wire x1="-1.473" y1="-0.983" x2="-1.473" y2="0.983" width="0.0508" layer="39"/>
+</package>
 </packages>
 <packages3d>
 <package3d name="2X03" urn="urn:adsk.eagle:package:22462/2" type="model">
@@ -24157,41 +24173,6 @@ Minimum input voltage level 1.8V. Maximum output voltage level 5.5V.</descriptio
 </device>
 </devices>
 </deviceset>
-<deviceset name="DIODE_ZENER" prefix="D">
-<description>&lt;B&gt;ZENER DIODE&lt;/B&gt;&lt;p&gt;</description>
-<gates>
-<gate name="G$1" symbol="DIODE_ZENER" x="0" y="0"/>
-</gates>
-<devices>
-<device name="DO-41" package="DO-41">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="0805" package="0805_D">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="" package="SOT23">
-<connects>
-<connect gate="G$1" pin="A" pad="1"/>
-<connect gate="G$1" pin="C" pad="3"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
 <deviceset name="DMG3406L" prefix="Q" uservalue="yes">
 <description>&lt;b&gt;Generic NPN MOSFET&lt;/b&gt;
 &lt;p&gt;
@@ -26158,6 +26139,50 @@ Dimensions: 5 mm x 20 mm
 <connect gate="G$1" pin="GND" pad="2 4"/>
 <connect gate="G$1" pin="IN" pad="1"/>
 <connect gate="G$1" pin="OUT" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="DIODE_ZENER" prefix="D">
+<description>&lt;B&gt;ZENER DIODE&lt;/B&gt;&lt;p&gt;</description>
+<gates>
+<gate name="G$1" symbol="DIODE_ZENER" x="0" y="0"/>
+</gates>
+<devices>
+<device name="DO-41" package="DO-41">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0805" package="0805_D">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="" package="SOT23">
+<connects>
+<connect gate="G$1" pin="A" pad="1"/>
+<connect gate="G$1" pin="C" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0603" package="0603_D">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
 </connects>
 <technologies>
 <technology name=""/>


### PR DESCRIPTION
# Pull Request (PR) into Circuits-Support-2020

## Part Description
This adds the 0603 footprint to the zener diode device we use in our library. This would be a great addition to protect power rails and other sensitive electronics from surges. 

## Additional Information
Part we used on the TSAL and HV board: [D15V0S1U2LP1608-7](https://www.diodes.com/assets/Datasheets/D12V0S1U2LP1608-_-D50V0S1U2LP1608.pdf)

## Checklist
- [ ] Did you create any new schematics or boards?
- - [ ] Did you *make a PR* for them in `circuits-2020`? If so, please pause until you get this PR merged.
- [x] Did you pull `master` into your branch?
- - [x] Did you *check for merge conflicts*?
- - [ ] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the above template?
- [x] Did you assign the right people for review (on the right)?
